### PR TITLE
Add `minAmountOut` with related types to `FlashnetClient`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flashnet/sdk",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",

--- a/src/client/FlashnetClient.ts
+++ b/src/client/FlashnetClient.ts
@@ -636,6 +636,7 @@ export class FlashnetClient {
     assetOutAddress: string;
     amountIn: string;
     maxSlippageBps: number;
+    minAmountOut: string;
     integratorFeeRateBps?: number;
     integratorPublicKey?: string;
   }): Promise<SwapResponse> {
@@ -688,6 +689,7 @@ export class FlashnetClient {
       assetOutTokenPublicKey: params.assetOutAddress,
       amountIn: params.amountIn.toString(),
       maxSlippageBps: params.maxSlippageBps.toString(),
+      minAmountOut: params.minAmountOut,
       totalIntegratorFeeRateBps: params.integratorFeeRateBps?.toString() || "0",
       nonce,
     });
@@ -707,6 +709,7 @@ export class FlashnetClient {
       assetOutAddress: params.assetOutAddress,
       amountIn: params.amountIn.toString(),
       maxSlippageBps: params.maxSlippageBps?.toString(),
+      minAmountOut: params.minAmountOut,
       assetInSparkTransferId: transferId,
       totalIntegratorFeeRateBps: params.integratorFeeRateBps?.toString() || "0",
       integratorPublicKey: params.integratorPublicKey || "",
@@ -751,6 +754,7 @@ export class FlashnetClient {
     initialAssetAddress: string;
     inputAmount: string;
     maxRouteSlippageBps: string;
+    minAmountOut: string;
     integratorFeeRateBps?: number;
     integratorPublicKey?: string;
   }): Promise<ExecuteRouteSwapResponse> {
@@ -845,6 +849,7 @@ export class FlashnetClient {
       initialSparkTransferId: initialTransferId,
       inputAmount: params.inputAmount.toString(),
       maxRouteSlippageBps: params.maxRouteSlippageBps.toString(),
+      minAmountOut: params.minAmountOut,
       nonce,
       defaultIntegratorFeeRateBps: params.integratorFeeRateBps?.toString(),
     });
@@ -863,6 +868,7 @@ export class FlashnetClient {
       initialSparkTransferId: initialTransferId,
       inputAmount: params.inputAmount.toString(),
       maxRouteSlippageBps: params.maxRouteSlippageBps.toString(),
+      minAmountOut: params.minAmountOut,
       nonce,
       signature: Buffer.from(signature).toString("hex"),
       integratorFeeRateBps: params.integratorFeeRateBps?.toString() || "0",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -271,6 +271,7 @@ export interface ExecuteSwapRequest {
   assetOutAddress: string;
   amountIn: string;
   maxSlippageBps?: string;
+  minAmountOut: string;
   assetInSparkTransferId: string;
   nonce: string;
   totalIntegratorFeeRateBps: string;
@@ -332,6 +333,7 @@ export interface ExecuteRouteSwapRequest {
   initialSparkTransferId: string;
   inputAmount: string;
   maxRouteSlippageBps: string;
+  minAmountOut: string;
   nonce: string;
   signature: string;
   integratorFeeRateBps?: string;
@@ -656,6 +658,7 @@ export interface ValidateAmmSwapData {
   assetOutTokenPublicKey: string;
   amountIn: string;
   maxSlippageBps: string;
+  minAmountOut: string;
   nonce: string;
   totalIntegratorFeeRateBps: string;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -657,8 +657,8 @@ export interface ValidateAmmSwapData {
   assetInTokenPublicKey: string;
   assetOutTokenPublicKey: string;
   amountIn: string;
-  maxSlippageBps: string;
   minAmountOut: string;
+  maxSlippageBps: string;
   nonce: string;
   totalIntegratorFeeRateBps: string;
 }

--- a/src/utils/intents.ts
+++ b/src/utils/intents.ts
@@ -110,8 +110,8 @@ export function generatePoolSwapIntentMessage(params: {
     assetInTokenPublicKey: params.assetInTokenPublicKey,
     assetOutTokenPublicKey: params.assetOutTokenPublicKey,
     amountIn: params.amountIn,
-    maxSlippageBps: params.maxSlippageBps,
     minAmountOut: params.minAmountOut,
+    maxSlippageBps: params.maxSlippageBps,
     nonce: params.nonce,
     totalIntegratorFeeRateBps: params.totalIntegratorFeeRateBps,
   };

--- a/src/utils/intents.ts
+++ b/src/utils/intents.ts
@@ -99,6 +99,7 @@ export function generatePoolSwapIntentMessage(params: {
   assetOutTokenPublicKey: string;
   amountIn: string;
   maxSlippageBps: string;
+  minAmountOut: string;
   totalIntegratorFeeRateBps: string;
   nonce: string;
 }): Uint8Array {
@@ -110,6 +111,7 @@ export function generatePoolSwapIntentMessage(params: {
     assetOutTokenPublicKey: params.assetOutTokenPublicKey,
     amountIn: params.amountIn,
     maxSlippageBps: params.maxSlippageBps,
+    minAmountOut: params.minAmountOut,
     nonce: params.nonce,
     totalIntegratorFeeRateBps: params.totalIntegratorFeeRateBps,
   };
@@ -231,6 +233,7 @@ export function generateRouteSwapIntentMessage(params: {
   initialSparkTransferId: string;
   inputAmount: string;
   maxRouteSlippageBps: string;
+  minAmountOut: string;
   nonce: string;
   defaultIntegratorFeeRateBps?: string;
 }): Uint8Array {
@@ -239,10 +242,11 @@ export function generateRouteSwapIntentMessage(params: {
     hops: params.hops,
     initialSparkTransferId: params.initialSparkTransferId,
     inputAmount: params.inputAmount,
-    minFinalOutputAmount: "0",
+    minFinalOutputAmount: params.minAmountOut,
     maxRouteSlippageBps: params.maxRouteSlippageBps,
     nonce: params.nonce,
-    defaultIntegratorFeeRateBps: params.defaultIntegratorFeeRateBps,
+    defaultIntegratorFeeRateBps:
+      params.defaultIntegratorFeeRateBps ?? "0",
   };
 
   return new TextEncoder().encode(JSON.stringify(signingPayload));


### PR DESCRIPTION
This PR does the following:
- `minAmountOut` support on a swap
- Related necessary modifications (intents and request calls)