### PR TITLE
Fix token info breaking build

### DIFF
--- a/src/client/FlashnetClient.ts
+++ b/src/client/FlashnetClient.ts
@@ -230,14 +230,19 @@ export class FlashnetClient {
 
     if (balance.tokenBalances) {
       for (const [tokenPubkey, tokenData] of balance.tokenBalances.entries()) {
+        const info =
+          "tokenInfo" in tokenData
+            ? tokenData.tokenInfo
+            : (tokenData as any).tokenMetadata;
+
         tokenBalances.set(tokenPubkey, {
           balance: BigInt(tokenData.balance),
           tokenInfo: {
-            tokenPublicKey: tokenData.tokenInfo.tokenPublicKey,
-            tokenName: tokenData.tokenInfo.tokenName,
-            tokenSymbol: tokenData.tokenInfo.tokenSymbol,
-            tokenDecimals: tokenData.tokenInfo.tokenDecimals,
-            maxSupply: tokenData.tokenInfo.maxSupply,
+            tokenPublicKey: info.tokenPublicKey,
+            tokenName: info.tokenName,
+            tokenSymbol: info.tokenSymbol,
+            tokenDecimals: info.tokenDecimals,
+            maxSupply: info.maxSupply,
           },
         });
       }
@@ -554,8 +559,9 @@ export class FlashnetClient {
           poolOwnerPublicKey: this.publicKey,
         };
 
-        const confirmResponse =
-          await this.typedApi.confirmInitialDeposit(confirmRequest);
+        const confirmResponse = await this.typedApi.confirmInitialDeposit(
+          confirmRequest
+        );
 
         if (!confirmResponse.confirmed) {
           throw new Error(


### PR DESCRIPTION
On main getting this on `pnpm build`

```
(!) [plugin typescript] src/client/FlashnetClient.ts (236:39): @rollup/plugin-typescript TS2339: Property 'tokenInfo' does not exist on type '{ balance: bigint; tokenInfo: TokenInfo; } | { balance: bigint; tokenMetadata: TokenMetadata; }'.
  Property 'tokenInfo' does not exist on type '{ balance: bigint; tokenMetadata: TokenMetadata; }'.
/Users/utxodetective/proj/a21/spark/ts-sdk/src/client/FlashnetClient.ts:236:39

236             tokenPublicKey: tokenData.tokenInfo.tokenPublicKey,
                                          ~~~~~~~~~

(!) [plugin typescript] src/client/FlashnetClient.ts (237:34): @rollup/plugin-typescript TS2339: Property 'tokenInfo' does not exist on type '{ balance: bigint; tokenInfo: TokenInfo; } | { balance: bigint; tokenMetadata: TokenMetadata; }'.
  Property 'tokenInfo' does not exist on type '{ balance: bigint; tokenMetadata: TokenMetadata; }'.
/Users/utxodetective/proj/a21/spark/ts-sdk/src/client/FlashnetClient.ts:237:34

237             tokenName: tokenData.tokenInfo.tokenName,
                                     ~~~~~~~~~

(!) [plugin typescript] src/client/FlashnetClient.ts (238:36): @rollup/plugin-typescript TS2339: Property 'tokenInfo' does not exist on type '{ balance: bigint; tokenInfo: TokenInfo; } | { balance: bigint; tokenMetadata: TokenMetadata; }'.
  Property 'tokenInfo' does not exist on type '{ balance: bigint; tokenMetadata: TokenMetadata; }'.
/Users/utxodetective/proj/a21/spark/ts-sdk/src/client/FlashnetClient.ts:238:36

238             tokenSymbol: tokenData.tokenInfo.tokenSymbol,
                                       ~~~~~~~~~

(!) [plugin typescript] src/client/FlashnetClient.ts (239:38): @rollup/plugin-typescript TS2339: Property 'tokenInfo' does not exist on type '{ balance: bigint; tokenInfo: TokenInfo; } | { balance: bigint; tokenMetadata: TokenMetadata; }'.
  Property 'tokenInfo' does not exist on type '{ balance: bigint; tokenMetadata: TokenMetadata; }'.
/Users/utxodetective/proj/a21/spark/ts-sdk/src/client/FlashnetClient.ts:239:38

239             tokenDecimals: tokenData.tokenInfo.tokenDecimals,
                                         ~~~~~~~~~

(!) [plugin typescript] src/client/FlashnetClient.ts (240:34): @rollup/plugin-typescript TS2339: Property 'tokenInfo' does not exist on type '{ balance: bigint; tokenInfo: TokenInfo; } | { balance: bigint; tokenMetadata: TokenMetadata; }'.
  Property 'tokenInfo' does not exist on type '{ balance: bigint; tokenMetadata: TokenMetadata; }'.
/Users/utxodetective/proj/a21/spark/ts-sdk/src/client/FlashnetClient.ts:240:34

240             maxSupply: tokenData.tokenInfo.maxSupply,
                                     ~~~~~~~~~

```