### PR TITLE
Refactor: Remove assetAAmount from withdrawHostFees and withdrawIntegratorFees methods

### DIFF
--- a/src/client/FlashnetClient.ts
+++ b/src/client/FlashnetClient.ts
@@ -1389,7 +1389,6 @@ export class FlashnetClient {
    */
   async withdrawHostFees(params: {
     lpIdentityPublicKey: string;
-    assetAAmount?: string;
     assetBAmount?: string;
   }): Promise<WithdrawHostFeesResponse> {
     await this.ensureInitialized();
@@ -1398,7 +1397,6 @@ export class FlashnetClient {
     const intentMessage = generateWithdrawHostFeesIntentMessage({
       hostPublicKey: this.publicKey,
       lpIdentityPublicKey: params.lpIdentityPublicKey,
-      assetAAmount: params.assetAAmount,
       assetBAmount: params.assetBAmount,
       nonce,
     });
@@ -1413,7 +1411,6 @@ export class FlashnetClient {
 
     const request: WithdrawHostFeesRequest = {
       lpIdentityPublicKey: params.lpIdentityPublicKey,
-      assetAAmount: params.assetAAmount,
       assetBAmount: params.assetBAmount,
       nonce,
       signature: Buffer.from(signature).toString("hex"),
@@ -1449,7 +1446,6 @@ export class FlashnetClient {
    */
   async withdrawIntegratorFees(params: {
     lpIdentityPublicKey: string;
-    assetAAmount?: string;
     assetBAmount?: string;
   }): Promise<WithdrawIntegratorFeesResponse> {
     await this.ensureInitialized();
@@ -1458,7 +1454,6 @@ export class FlashnetClient {
     const intentMessage = generateWithdrawIntegratorFeesIntentMessage({
       integratorPublicKey: this.publicKey,
       lpIdentityPublicKey: params.lpIdentityPublicKey,
-      assetAAmount: params.assetAAmount,
       assetBAmount: params.assetBAmount,
       nonce,
     });
@@ -1474,7 +1469,6 @@ export class FlashnetClient {
     const request: WithdrawIntegratorFeesRequest = {
       integratorPublicKey: this.publicKey,
       lpIdentityPublicKey: params.lpIdentityPublicKey,
-      assetAAmount: params.assetAAmount,
       assetBAmount: params.assetBAmount,
       nonce,
       signature: Buffer.from(signature).toString("hex"),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -237,7 +237,6 @@ export interface GetHostResponse {
 
 export interface WithdrawHostFeesRequest {
   lpIdentityPublicKey: string;
-  assetAAmount?: string;
   assetBAmount?: string;
   nonce: string;
   signature: string;
@@ -943,7 +942,6 @@ export interface GetHostFeesResponse {
   hostNamespace: string;
   feeRecipientType: string;
   pools: HostPoolFees[];
-  totalAssetAFees?: string;
   totalAssetBFees?: string;
 }
 
@@ -951,16 +949,13 @@ export interface GetHostFeesResponse {
 export interface IntegratorPoolFees {
   poolId: string;
   hostNamespace?: string;
-  assetAPubkey: string;
   assetBPubkey: string;
-  assetAFees: string;
   assetBFees: string;
 }
 
 export interface GetIntegratorFeesResponse {
   integratorPublicKey: string;
   pools: IntegratorPoolFees[];
-  totalAssetAFees?: string;
   totalAssetBFees?: string;
 }
 

--- a/src/utils/intents.ts
+++ b/src/utils/intents.ts
@@ -186,7 +186,6 @@ export function generateRegisterHostIntentMessage(params: {
 export function generateWithdrawHostFeesIntentMessage(params: {
   hostPublicKey: string;
   lpIdentityPublicKey: string;
-  assetAAmount?: string;
   assetBAmount?: string;
   nonce: string;
 }): Uint8Array {
@@ -194,7 +193,7 @@ export function generateWithdrawHostFeesIntentMessage(params: {
   const signingPayload = {
     hostPublicKey: params.hostPublicKey,
     lpIdentityPublicKey: params.lpIdentityPublicKey,
-    assetAAmount: params.assetAAmount,
+    assetAAmount: "0",
     assetBAmount: params.assetBAmount,
     nonce: params.nonce,
   };
@@ -209,14 +208,13 @@ export function generateWithdrawHostFeesIntentMessage(params: {
 export function generateWithdrawIntegratorFeesIntentMessage(params: {
   integratorPublicKey: string;
   lpIdentityPublicKey: string;
-  assetAAmount?: string;
   assetBAmount?: string;
   nonce: string;
 }): Uint8Array {
   const signingPayload: ValidateAmmWithdrawIntegratorFeesData = {
     integratorPublicKey: params.integratorPublicKey,
     lpIdentityPublicKey: params.lpIdentityPublicKey,
-    assetAAmount: params.assetAAmount,
+    assetAAmount: "0",
     assetBAmount: params.assetBAmount,
     nonce: params.nonce,
   };


### PR DESCRIPTION

- Removed the optional assetAAmount parameter from the withdrawHostFees and withdrawIntegratorFees methods in FlashnetClient.
- Updated the corresponding intent message generation functions to default assetAAmount to "0".
- Adjusted types to reflect the removal of assetAAmount from the WithdrawHostFeesRequest and GetIntegratorFeesResponse interfaces.