### PR TITLE
Add checkClawbackEligibility method and related types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flashnet/sdk",
-  "version": "0.3.33",
+  "version": "0.3.34",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",

--- a/src/api/typed-endpoints.ts
+++ b/src/api/typed-endpoints.ts
@@ -513,6 +513,20 @@ export class TypedAmmApi {
   ): Promise<Types.ClawbackResponse> {
     return this.client.ammPost<Types.ClawbackResponse>("/v1/clawback", request);
   }
+
+  /**
+   * Check if a transfer is eligible for clawback
+   * @POST /v1/check_clawback_eligibility
+   * @requires Bearer token
+   */
+  async checkClawbackEligibility(
+    request: Types.CheckClawbackEligibilityRequest
+  ): Promise<Types.CheckClawbackEligibilityResponse> {
+    return this.client.ammPost<Types.CheckClawbackEligibilityResponse>(
+      "/v1/check_clawback_eligibility",
+      request
+    );
+  }
 }
 
 /**

--- a/src/client/FlashnetClient.ts
+++ b/src/client/FlashnetClient.ts
@@ -989,7 +989,16 @@ export class FlashnetClient {
   ): Promise<SimulateSwapResponse> {
     await this.ensureInitialized();
     await this.ensurePingOk();
-    return this.typedApi.simulateSwap(params);
+
+    // Clip decimals from integratorBps if it's a number
+    const processedParams = {
+      ...params,
+      ...(params.integratorBps !== undefined && {
+        integratorBps: Math.floor(params.integratorBps),
+      }),
+    };
+
+    return this.typedApi.simulateSwap(processedParams);
   }
 
   /**

--- a/src/client/FlashnetClient.ts
+++ b/src/client/FlashnetClient.ts
@@ -13,6 +13,8 @@ import {
   type AddLiquidityResponse,
   type AllLpPositionsResponse,
   type AllowedAssetsResponse,
+  type CheckClawbackEligibilityRequest,
+  type CheckClawbackEligibilityResponse,
   type ClaimEscrowRequest,
   type ClaimEscrowResponse,
   type ClawbackRequest,
@@ -146,7 +148,7 @@ export interface FlashnetClientOptions {
 type Tuple<
   T,
   N extends number,
-  Acc extends readonly T[] = [],
+  Acc extends readonly T[] = []
 > = Acc["length"] extends N ? Acc : Tuple<T, N, [...Acc, T]>;
 
 /**
@@ -1944,6 +1946,34 @@ export class FlashnetClient {
     }
 
     return response;
+  }
+
+  /**
+   * Check if a transfer is eligible for clawback
+   *
+   * This is a read-only check that verifies:
+   * - The transfer exists and is valid
+   * - The authenticated user is the original sender
+   * - The transfer is not already reserved or spent
+   * - The transfer has not been claimed/settled
+   * - The transfer is less than 23 hours old
+   *
+   * Note: This does NOT initiate a clawback, only checks eligibility.
+   *
+   * @param sparkTransferId - The Spark transfer ID to check
+   * @returns Response indicating if the transfer is eligible and any error message
+   */
+  async checkClawbackEligibility(params: {
+    sparkTransferId: string;
+  }): Promise<CheckClawbackEligibilityResponse> {
+    await this.ensureInitialized();
+    await this.ensurePingOk();
+
+    const request: CheckClawbackEligibilityRequest = {
+      sparkTransferId: params.sparkTransferId,
+    };
+
+    return this.typedApi.checkClawbackEligibility(request);
   }
 
   // ===== Token Address Operations =====

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1273,6 +1273,15 @@ export interface ClawbackRequest {
   signature: string;
 }
 
+export interface CheckClawbackEligibilityRequest {
+  sparkTransferId: string;
+}
+
+export interface CheckClawbackEligibilityResponse {
+  accepted: boolean;
+  error?: string;
+}
+
 /**
  * Response after successfully funding an escrow contract.
  */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -445,7 +445,7 @@ export interface SimulateSwapRequest {
   assetInAddress: string;
   assetOutAddress: string;
   amountIn: string;
-  integratorBps?: string;
+  integratorBps?: number;
 }
 
 export interface SimulateSwapResponse {


### PR DESCRIPTION
- Implemented the checkClawbackEligibility method in FlashnetClient to verify if a transfer is eligible for clawback.
- Added CheckClawbackEligibilityRequest and CheckClawbackEligibilityResponse interfaces in types for request and response structure.
- Updated TypedAmmApi to include the new endpoint for checking clawback eligibility.