### PR TITLE
[UX-08] Add ExecutionClient for multi-deposit intents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ tsconfig.tsbuildinfo
 
 # Bun
 bun.lockb
+
+# Claude Code hooks (stubs for cross-repo hook compatibility)
+.claude/

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,20 @@
 // Export all types
 
 // Export execution layer client (new — talks to flashnet-execution gateway)
-export { ExecutionClient, Conductor, swap, swapBTC } from "./src/execution";
+export {
+  ExecutionClient,
+  Conductor,
+  swap,
+  swapBTC,
+  approveToken,
+  swapWithApproval,
+  encodeWithdrawSats,
+  encodeWithdrawToken,
+  queryBridgedTokenAddress,
+  waitForBridgedTokenAddress,
+  withdrawSats,
+  withdrawToken,
+} from "./src/execution";
 export {
   fetchTokenInfo,
   fetchTokenBalance,
@@ -31,6 +44,8 @@ export type {
   CreateBTCPoolParams,
   CreatePoolParams,
   PermitSignature,
+  BridgeConfig,
+  WithdrawResult,
 } from "./src/execution";
 export type {
   CanonicalIntentAction,

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,8 @@
 // Export all types
 
 // Export execution layer client (new — talks to flashnet-execution gateway)
-export { ExecutionClient } from "./src/execution";
+export { ExecutionClient, Conductor } from "./src/execution";
+export type { SwapParams, SwapBTCParams } from "./src/execution";
 export type {
   CanonicalIntentAction,
   CanonicalIntentMessage,

--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,37 @@
 // Export all types
 
 // Export execution layer client (new — talks to flashnet-execution gateway)
-export { ExecutionClient, Conductor } from "./src/execution";
-export type { SwapParams, SwapBTCParams } from "./src/execution";
+export { ExecutionClient, Conductor, swap, swapBTC } from "./src/execution";
+export {
+  fetchTokenInfo,
+  fetchTokenBalance,
+  fetchNativeBalance,
+  fetchAllowance,
+  fetchNonce,
+} from "./src/execution";
+export { getPoolAddress, fetchPoolInfo, sortTokens } from "./src/execution";
+export {
+  priceToSqrtPriceX96,
+  sqrtPriceX96ToPrice,
+  fullRangeTicks,
+  FEE_TIERS,
+} from "./src/execution";
+export { encodeCreateBTCPool, encodeCreatePoolParams } from "./src/execution";
+export type {
+  SwapParams,
+  SwapBTCParams,
+  ConductorConfig,
+  EvmTransactionSigner,
+  UnsignedTransaction,
+  SwapResult,
+  SwapRequest,
+  SwapBTCRequest,
+  TokenInfo,
+  PoolInfo,
+  CreateBTCPoolParams,
+  CreatePoolParams,
+  PermitSignature,
+} from "./src/execution";
 export type {
   CanonicalIntentAction,
   CanonicalIntentMessage,

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,20 @@
 // Export all types
 
+// Export execution layer client (new — talks to flashnet-execution gateway)
+export { ExecutionClient } from "./src/execution";
+export type {
+  CanonicalIntentAction,
+  CanonicalIntentMessage,
+  CanonicalTransferEntry,
+  Deposit,
+  DepositAsset,
+  DepositIntentParams,
+  ExecuteIntentParams,
+  ExecuteResponse,
+  ExecutionClientConfig,
+  ExecutionSigner,
+} from "./src/execution";
+
 export type { RequestOptions } from "./src/api/client";
 // Export API client and typed endpoints
 export { ApiClient } from "./src/api/client";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6406 @@
+{
+  "name": "@flashnet/sdk",
+  "version": "0.5.7",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@flashnet/sdk",
+      "version": "0.5.7",
+      "license": "MIT",
+      "dependencies": {
+        "bech32": "^2.0.0",
+        "fast-sha256": "1.3.0",
+        "light-bolt11-decoder": "^3.2.0",
+        "viem": "^2.47.6"
+      },
+      "devDependencies": {
+        "@biomejs/biome": "2.0.5",
+        "@buildonspark/issuer-sdk": "latest",
+        "@buildonspark/spark-sdk": "latest",
+        "@rollup/plugin-typescript": "^12.1.4",
+        "@types/bun": "latest",
+        "@types/jest": "^30.0.0",
+        "@types/node": "^20.19.7",
+        "bun": "^1.2.21",
+        "jest": "^30.1.2",
+        "rollup": "^4.45.0",
+        "ts-jest": "^29.4.1",
+        "tslib": "^2.8.1",
+        "typescript": "^5.8.3"
+      },
+      "peerDependencies": {
+        "@buildonspark/issuer-sdk": "latest",
+        "@buildonspark/spark-sdk": "latest",
+        "react-native-get-random-values": ">=1.11.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "@buildonspark/issuer-sdk": {
+          "optional": true
+        },
+        "@buildonspark/spark-sdk": {
+          "optional": true
+        },
+        "react-native-get-random-values": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.28.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.28.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.28.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.0.5",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.0.5",
+        "@biomejs/cli-darwin-x64": "2.0.5",
+        "@biomejs/cli-linux-arm64": "2.0.5",
+        "@biomejs/cli-linux-arm64-musl": "2.0.5",
+        "@biomejs/cli-linux-x64": "2.0.5",
+        "@biomejs/cli-linux-x64-musl": "2.0.5",
+        "@biomejs/cli-win32-arm64": "2.0.5",
+        "@biomejs/cli-win32-x64": "2.0.5"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.0.5",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.0.5.tgz",
+      "integrity": "sha512-DRpGxBgf5Z7HUFcNUB6n66UiD4VlBlMpngNf32wPraxX8vYU6N9cb3xQWOXIQVBBQ64QfsSLJnjNu79i/LNmSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.0.5.tgz",
+      "integrity": "sha512-FQTfDNMXOknf8+g9Eede2daaduRjTC2SNbfWPNFMadN9K3UKjeZ62jwiYxztPaz9zQQsZU8VbddQIaeQY5CmIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.0.5.tgz",
+      "integrity": "sha512-OpflTCOw/ElEs7QZqN/HFaSViPHjAsAPxFJ22LhWUWvuJgcy/Z8+hRV0/3mk/ZRWy5A6fCDKHZqAxU+xB6W4mA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.0.5.tgz",
+      "integrity": "sha512-znpfydUDPuDkyBTulnODrQVK2FaG/4hIOPcQSsF2GeauQOYrBAOplj0etGB0NUrr0dFsvaQ15nzDXYb60ACoiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.0.5.tgz",
+      "integrity": "sha512-9lmjCnajAzpZXbav2P6D87ugkhnaDpJtDvOH5uQbY2RXeW6Rq18uOUltxgacGBP+d8GusTr+s3IFOu7SN0Ok8g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.0.5.tgz",
+      "integrity": "sha512-CP2wKQB+gh8HdJTFKYRFETqReAjxlcN9AlYDEoye8v2eQp+L9v+PUeDql/wsbaUhSsLR0sjj3PtbBtt+02AN3A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.0.5.tgz",
+      "integrity": "sha512-Sw3rz2m6bBADeQpr3+MD7Ch4E1l15DTt/+dfqKnwkm3cn4BrYwnArmvKeZdVsFRDjMyjlKIP88bw1r7o+9aqzw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
+      "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
+      "dev": true,
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@buildonspark/issuer-sdk": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@buildonspark/issuer-sdk/-/issuer-sdk-0.1.22.tgz",
+      "integrity": "sha512-1lEFX8zUJ9ipTDkBQ0vPPLm5ncEN9LTKje3vFiLRlHfc+Pw5tYYvjo1bn1eicyNHo6IoKJDTxHbJ0Rjz5fRVCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@buildonspark/spark-sdk": "0.7.4",
+        "@noble/curves": "^1.9.7",
+        "@scure/btc-signer": "^1.5.0",
+        "buffer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.2.0",
+        "react-native": ">=0.71.0",
+        "react-native-get-random-values": ">=1.11.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "react-native-get-random-values": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@buildonspark/spark-sdk": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@buildonspark/spark-sdk/-/spark-sdk-0.7.4.tgz",
+      "integrity": "sha512-DzlN6EkXyKLZVvq3ujZD6/uFauBkSL7kZEgE6moI+xuFU0HZ3qrao1zbNCv67yPGoK9h8s2YfpEl++s1ybiVjg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.2.5",
+        "@lightsparkdev/core": "^1.4.9",
+        "@noble/curves": "^1.9.7",
+        "@noble/hashes": "^1.7.0",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^2.0.0",
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.203.0",
+        "@opentelemetry/instrumentation-undici": "^0.14.0",
+        "@opentelemetry/sdk-trace-base": "^2.0.0",
+        "@opentelemetry/sdk-trace-node": "^2.0.1",
+        "@opentelemetry/sdk-trace-web": "^2.0.1",
+        "@scure/base": "^1.2.4",
+        "@scure/bip32": "^1.6.2",
+        "@scure/bip39": "^1.5.4",
+        "@scure/btc-signer": "^1.5.0",
+        "abort-controller-x": "^0.4.3",
+        "abortcontroller-polyfill": "^1.7.8",
+        "async-mutex": "^0.5.0",
+        "bare-crypto": "^1.9.2",
+        "bare-fetch": "^2.4.1",
+        "buffer": "^6.0.3",
+        "eventemitter3": "^5.0.1",
+        "js-base64": "^3.7.7",
+        "light-bolt11-decoder": "^3.2.0",
+        "nice-grpc": "^2.1.10",
+        "nice-grpc-client-middleware-retry": "^3.1.10",
+        "nice-grpc-common": "^2.0.2",
+        "nice-grpc-opentelemetry": "^0.1.18",
+        "nice-grpc-web": "^3.3.7",
+        "ts-proto": "2.8.3",
+        "ua-parser-js": "^2.0.6",
+        "uuidv7": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.2.0",
+        "react-native": ">=0.71.0",
+        "react-native-get-random-values": ">=1.11.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "react-native-get-random-values": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
+      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
+      "version": "5.3.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.2.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "jest-message-util": "30.2.0",
+        "jest-util": "30.2.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.2.0",
+        "@jest/pattern": "30.0.1",
+        "@jest/reporters": "30.2.0",
+        "@jest/test-result": "30.2.0",
+        "@jest/transform": "30.2.0",
+        "@jest/types": "30.2.0",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "exit-x": "^0.2.2",
+        "graceful-fs": "^4.2.11",
+        "jest-changed-files": "30.2.0",
+        "jest-config": "30.2.0",
+        "jest-haste-map": "30.2.0",
+        "jest-message-util": "30.2.0",
+        "jest-regex-util": "30.0.1",
+        "jest-resolve": "30.2.0",
+        "jest-resolve-dependencies": "30.2.0",
+        "jest-runner": "30.2.0",
+        "jest-runtime": "30.2.0",
+        "jest-snapshot": "30.2.0",
+        "jest-util": "30.2.0",
+        "jest-validate": "30.2.0",
+        "jest-watcher": "30.2.0",
+        "micromatch": "^4.0.8",
+        "pretty-format": "30.2.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.2.0",
+        "@jest/types": "30.2.0",
+        "@types/node": "*",
+        "jest-mock": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "30.2.0",
+        "jest-snapshot": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.2.0",
+        "@sinonjs/fake-timers": "^13.0.0",
+        "@types/node": "*",
+        "jest-message-util": "30.2.0",
+        "jest-mock": "30.2.0",
+        "jest-util": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.2.0",
+        "@jest/expect": "30.2.0",
+        "@jest/types": "30.2.0",
+        "jest-mock": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "30.2.0",
+        "@jest/test-result": "30.2.0",
+        "@jest/transform": "30.2.0",
+        "@jest/types": "30.2.0",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "collect-v8-coverage": "^1.0.2",
+        "exit-x": "^0.2.2",
+        "glob": "^10.3.10",
+        "graceful-fs": "^4.2.11",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^5.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "30.2.0",
+        "jest-util": "30.2.0",
+        "jest-worker": "30.2.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.2",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/snapshot-utils": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.2.0",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "natural-compare": "^1.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "30.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "callsites": "^3.1.0",
+        "graceful-fs": "^4.2.11"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.2.0",
+        "@jest/types": "30.2.0",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "collect-v8-coverage": "^1.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "30.2.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.2.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/types": "30.2.0",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "babel-plugin-istanbul": "^7.0.1",
+        "chalk": "^4.1.2",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.2.0",
+        "jest-regex-util": "30.0.1",
+        "jest-util": "30.2.0",
+        "micromatch": "^4.0.8",
+        "pirates": "^4.0.7",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^5.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@lightsparkdev/core": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lightsparkdev/core/-/core-1.5.1.tgz",
+      "integrity": "sha512-IHgxWxAfOvHh6sdv3YqW9xk16H/sfTfA0nLC6FfU8TWHWb7ZU3/UO6QjR0a5a2qR/Fv5ZlS6DSzM7ST7Qx6N4Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.9.7",
+        "dayjs": "^1.11.7",
+        "graphql": "^16.6.0",
+        "graphql-ws": "^5.11.3",
+        "ws": "^8.12.1",
+        "zen-observable-ts": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.203.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.203.0.tgz",
+      "integrity": "sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.1.tgz",
+      "integrity": "sha512-XHzhwRNkBpeP8Fs/qjGrAf9r9PRv67wkJQ/7ZPaBQQ68DYlTBBx5MF9LvPx7mhuXcDessKK2b+DcxqwpgkcivQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.203.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.203.0.tgz",
+      "integrity": "sha512-ke1qyM+3AK2zPuBPb6Hk/GCsc5ewbLvPNkEuELx/JmANeEp6ZjnZ+wypPAJSucTw0wvCGrUaibDSdcrGFoWxKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.203.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-undici": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.14.0.tgz",
+      "integrity": "sha512-2HN+7ztxAReXuxzrtA3WboAKlfP5OsPA57KQn2AdYZbJ3zeRPcLXyW4uO/jpLE6PLm0QRtmeGCmfYpqRlwgSwg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.203.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
+      "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
+      "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.6.1.tgz",
+      "integrity": "sha512-Hh2i4FwHWRFhnO2Q/p6svMxy8MPsNCG0uuzUY3glqm0rwM0nQvbTO1dXSp9OqQoTKXcQzaz9q1f65fsurmOhNw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.6.1",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-web": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.6.1.tgz",
+      "integrity": "sha512-JQevIjBlWGcKBfuwe7tdxGR/75RERsf1OOIvUzPKq86J8qhzkyjnLTTuPNPLRQF1xxEe65W5aI1Uwl6yWUGPQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@oven/bun-darwin-aarch64": {
+      "version": "1.3.10",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oven/bun-darwin-x64": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-x64/-/bun-darwin-x64-1.3.10.tgz",
+      "integrity": "sha512-Nhssuh7GBpP5PiDSOl3+qnoIG7PJo+ec2oomDevnl9pRY6x6aD2gRt0JE+uf+A8Om2D6gjeHCxjEdrw5ZHE8mA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oven/bun-darwin-x64-baseline": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-x64-baseline/-/bun-darwin-x64-baseline-1.3.10.tgz",
+      "integrity": "sha512-w1gaTlqU0IJCmJ1X+PGHkdNU1n8Gemx5YKkjhkJIguvFINXEBB5U1KG82QsT65Tk4KyNMfbLTlmy4giAvUoKfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oven/bun-linux-aarch64": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-aarch64/-/bun-linux-aarch64-1.3.10.tgz",
+      "integrity": "sha512-OUgPHfL6+PM2Q+tFZjcaycN3D7gdQdYlWnwMI31DXZKY1r4HINWk9aEz9t/rNaHg65edwNrt7dsv9TF7xK8xIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-linux-aarch64-musl": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-aarch64-musl/-/bun-linux-aarch64-musl-1.3.10.tgz",
+      "integrity": "sha512-Ui5pAgM7JE9MzHokF0VglRMkbak3lTisY4Mf1AZutPACXWgKJC5aGrgnHBfkl7QS6fEeYb0juy1q4eRznRHOsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-linux-x64": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64/-/bun-linux-x64-1.3.10.tgz",
+      "integrity": "sha512-bzUgYj/PIZziB/ZesIP9HUyfvh6Vlf3od+TrbTTyVEuCSMKzDPQVW/yEbRp0tcHO3alwiEXwJDrWrHAguXlgiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-linux-x64-baseline": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-baseline/-/bun-linux-x64-baseline-1.3.10.tgz",
+      "integrity": "sha512-oqvMDYpX6dGJO03HgO5bXuccEsH3qbdO3MaAiAlO4CfkBPLUXz3N0DDElg5hz0L6ktdDVKbQVE5lfe+LAUISQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-linux-x64-musl": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-musl/-/bun-linux-x64-musl-1.3.10.tgz",
+      "integrity": "sha512-poVXvOShekbexHq45b4MH/mRjQKwACAC8lHp3Tz/hEDuz0/20oncqScnmKwzhBPEpqJvydXficXfBYuSim8opw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-linux-x64-musl-baseline": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-musl-baseline/-/bun-linux-x64-musl-baseline-1.3.10.tgz",
+      "integrity": "sha512-/hOZ6S1VsTX6vtbhWVL9aAnOrdpuO54mAGUWpTdMz7dFG5UBZ/VUEiK0pBkq9A1rlBk0GeD/6Y4NBFl8Ha7cRA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-windows-aarch64": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@oven/bun-windows-aarch64/-/bun-windows-aarch64-1.3.10.tgz",
+      "integrity": "sha512-GXbz2swvN2DLw2dXZFeedMxSJtI64xQ9xp9Eg7Hjejg6mS2E4dP1xoQ2yAo2aZPi/2OBPAVaGzppI2q20XumHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oven/bun-windows-x64": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@oven/bun-windows-x64/-/bun-windows-x64-1.3.10.tgz",
+      "integrity": "sha512-qaS1In3yfC/Z/IGQriVmF8GWwKuNqiw7feTSJWaQhH5IbL6ENR+4wGNPniZSJFaM/SKUO0e/YCRdoVBvgU4C1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oven/bun-windows-x64-baseline": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@oven/bun-windows-x64-baseline/-/bun-windows-x64-baseline-1.3.10.tgz",
+      "integrity": "sha512-gh3UAHbUdDUG6fhLc1Csa4IGdtghue6U8oAIXWnUqawp6lwb3gOCRvp25IUnLF5vUHtgfMxuEUYV7YA2WxVutw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.2.9",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@rollup/plugin-typescript": {
+      "version": "12.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.1.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.14.0||^3.0.0||^4.0.0",
+        "tslib": "*",
+        "typescript": ">=3.7.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        },
+        "tslib": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/btc-signer": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@scure/btc-signer/-/btc-signer-1.8.1.tgz",
+      "integrity": "sha512-8nX9T++dFyKpvqksNHfSi9CgRsGnHAQtCdIQ1y1GmbCGLpV97v4MUyemUUT6uDumKL3oo3m4niyY6A32nmdLuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5",
+        "micro-packed": "~0.7.3"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.48",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.5",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/bun": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.11.tgz",
+      "integrity": "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bun-types": "1.3.11"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.35",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/zen-observable": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
+      "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.11.1",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/abort-controller-x": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.4.3.tgz",
+      "integrity": "sha512-VtUwTNU8fpMwvWGn4xE93ywbogTYsuT+AUxAXOeelbXuQVIwNmC5YLeho9sH4vZ4ITW8414TTAOG1nW6uIVHCA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/abortcontroller-polyfill": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.8.tgz",
+      "integrity": "sha512-9f1iZ2uWh92VcrU9Y8x+LdM4DLj75VE0MJB8zuF1iUnroEptStw+DQ8EQPMUdfe5k+PkB1uUfDQfWbhstH8LrQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/babel-jest": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "30.2.0",
+        "@types/babel__core": "^7.20.5",
+        "babel-plugin-istanbul": "^7.0.1",
+        "babel-preset-jest": "30.2.0",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "7.0.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "workspaces": [
+        "test/babel-8"
+      ],
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-instrument": "^6.0.2",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/babel__core": "^7.20.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "30.2.0",
+        "babel-preset-current-node-syntax": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bare-ansi-escapes": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/bare-ansi-escapes/-/bare-ansi-escapes-2.2.3.tgz",
+      "integrity": "sha512-02ES4/E2RbrtZSnHJ9LntBhYkLA6lPpSEeP8iqS3MccBIVhVBlEmruF1I7HZqx5Q8aiTeYfQVeqmrU9YO2yYoQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-stream": "^2.6.5"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-assert": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bare-assert/-/bare-assert-1.2.0.tgz",
+      "integrity": "sha512-c6uvgvTJBspTDxtVnPgrBKmLgcpW3Fp72NVKDLg6oT4QjQbhGtvrkHMhGYMK1sh4vjBHOBmuUalyt9hSzV37fQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-inspect": "^3.1.2"
+      }
+    },
+    "node_modules/bare-buffer": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/bare-buffer/-/bare-buffer-3.6.0.tgz",
+      "integrity": "sha512-/maRWEQ2eBkVNMbNFVsq1pHXJYVj4Y3AixwruB24eKZDs5Gtu0fixzvjYmBIuTsBMtVH5Yb27pQO9BhFa+IlIQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.20.0"
+      }
+    },
+    "node_modules/bare-crypto": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/bare-crypto/-/bare-crypto-1.13.4.tgz",
+      "integrity": "sha512-JiCZ5l2YOG1y8J7yy1BCAKTCZrPnHLb7pDRIdurBTOn5oIwBQDIv8iH5Pl2V85vzjl1NZXRfNY4HZLsE942jJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-assert": "^1.2.0",
+        "bare-stream": "^2.6.3"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-dns": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/bare-dns/-/bare-dns-2.1.4.tgz",
+      "integrity": "sha512-abwjHmpWqSRNB7V5615QxPH92L71AVzFm/kKTs8VYiNTAi2xVdonpv0BjJ0hwXLwomoW+xsSOPjW6PZPO14asg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.7.0"
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fetch": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/bare-fetch/-/bare-fetch-2.8.1.tgz",
+      "integrity": "sha512-HQ86IJccd+1iIQ9LcXh+41YdI+/DH0GD6PhwdCfaHNd1L8d7p5N5jzMWdM7YbDad9MC8x5bDU1GtgKDscm2ypw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-form-data": "^1.2.0",
+        "bare-http1": "^4.5.2",
+        "bare-https": "^2.0.0",
+        "bare-stream": "^2.9.1",
+        "bare-url": "^2.4.0",
+        "bare-zlib": "^1.3.0"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-form-data": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bare-form-data/-/bare-form-data-1.2.1.tgz",
+      "integrity": "sha512-DFZhp5Tn0S7TjII/xhgLl2BNU6f7l5QbIW/YH7TjzQVnxLa8SaMSbl77jpy0ZR1oUnAo0a7NHJ9QAOU6PPr0Jg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-buffer": "^3.6.0",
+        "bare-stream": "^2.6.5"
+      }
+    },
+    "node_modules/bare-http-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/bare-http-parser/-/bare-http-parser-1.1.3.tgz",
+      "integrity": "sha512-+dhVvQi6brHq14L/XHNRQ+TLuVE76VjRmMt61wVEtS+Od8xUslfMHWJN/ZjIIt3RtTG6vPuA+x9cOh7KrkBJsA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-http1": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/bare-http1/-/bare-http1-4.5.5.tgz",
+      "integrity": "sha512-ADITiRo0huP76JGMbv6Arsh9KehHqjEBoYcmjvAo67IY78+/9mV2MeKLLCkiJSFxA85T/m8cTaE44OwJQCcwdw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.6.0",
+        "bare-http-parser": "^1.1.1",
+        "bare-stream": "^2.10.0",
+        "bare-tcp": "^2.2.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-https": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/bare-https/-/bare-https-2.1.3.tgz",
+      "integrity": "sha512-0TI/mJXQGYXmG7UUyWEG+KCJusayIAQLywUjFAskDoKuxfqVnGF+M/mTMrEV8J64DaIdU+5x761FvgmT7M68tA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-http1": "^4.4.0",
+        "bare-tcp": "^2.2.0",
+        "bare-tls": "^2.0.0"
+      }
+    },
+    "node_modules/bare-inspect": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/bare-inspect/-/bare-inspect-3.1.4.tgz",
+      "integrity": "sha512-jfW5KRA84o3REpI6Vr4nbvMn+hqVAw8GU1mMdRwUsY5yJovQamxYeKGVKGqdzs+8ZbG4jRzGUXP/3Ji/DnqfPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-ansi-escapes": "^2.1.0",
+        "bare-type": "^1.0.0"
+      },
+      "engines": {
+        "bare": ">=1.18.0"
+      }
+    },
+    "node_modules/bare-net": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/bare-net/-/bare-net-2.3.1.tgz",
+      "integrity": "sha512-MypSqDKpDU2Xt7FIfazn5yGvRnV09gFcIPHGWstW0gxuzA4tucTcwJSZeos97C4F89vtU5oGwXDN/HrGN6Y4Jw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.2.2",
+        "bare-pipe": "^4.0.0",
+        "bare-stream": "^2.0.0",
+        "bare-tcp": "^2.0.0"
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.7.tgz",
+      "integrity": "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-pipe": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/bare-pipe/-/bare-pipe-4.1.5.tgz",
+      "integrity": "sha512-6OfxaG8JSkRh3Gc4hzHRsxNt+yu2PpN7lrv1V+T78GdknWQkVGwiEvu4m+1nbfk8cMVQ0TGxRvQ90XA4rhnTuw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.0.0",
+        "bare-stream": "^2.0.0"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.12.0.tgz",
+      "integrity": "sha512-w28i8lkBgREV3rPXGbgK+BO66q+ZpKqRWrZLiCdmmUlLPrQ45CzkvRhN+7lnv00Gpi2zy5naRxnUFAxCECDm9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-tcp": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/bare-tcp/-/bare-tcp-2.2.7.tgz",
+      "integrity": "sha512-rjpqNQ2cOCkNo3NeYA/W4GTK3DRkl8sDHO3uos+AEswUjLC8XXMQF8WrJCSjlIowCbS6NUVxKE92X5RGXjyefg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-dns": "^2.0.4",
+        "bare-events": "^2.5.4",
+        "bare-stream": "^2.6.4"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      }
+    },
+    "node_modules/bare-tls": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bare-tls/-/bare-tls-2.2.1.tgz",
+      "integrity": "sha512-hZ+ZqwrUO4dyH7/6WYkYWjgAFNJKjzwEYJiDaMnMs+eRleBDjQ3CvNZawpkw0Ar9jnM9NZK6+f6GqjkZ2FLGmQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-net": "^2.0.1",
+        "bare-stream": "^2.6.4"
+      },
+      "engines": {
+        "bare": ">=1.7.0"
+      }
+    },
+    "node_modules/bare-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bare-type/-/bare-type-1.1.0.tgz",
+      "integrity": "sha512-LdtnnEEYldOc87Dr4GpsKnStStZk3zfgoEMXy8yvEZkXrcCv9RtYDrUYWFsBQHtaB0s1EUWmcvS6XmEZYIj3Bw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.2.0"
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
+      "integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/bare-zlib": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/bare-zlib/-/bare-zlib-1.3.1.tgz",
+      "integrity": "sha512-VP93GFzhrTdWh9mXNocn7XsP/nF5JQluiiSsbTvsQ4yIYlhEHRMF9lQmZZDXwzK9PNYaVGUV1bdQuqp0Mj7MHw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-stream": "^2.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bech32": {
+      "version": "2.0.0",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bun": {
+      "version": "1.3.10",
+      "cpu": [
+        "arm64",
+        "x64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "bin": {
+        "bun": "bin/bun.exe",
+        "bunx": "bin/bunx.exe"
+      },
+      "optionalDependencies": {
+        "@oven/bun-darwin-aarch64": "1.3.10",
+        "@oven/bun-darwin-x64": "1.3.10",
+        "@oven/bun-darwin-x64-baseline": "1.3.10",
+        "@oven/bun-linux-aarch64": "1.3.10",
+        "@oven/bun-linux-aarch64-musl": "1.3.10",
+        "@oven/bun-linux-x64": "1.3.10",
+        "@oven/bun-linux-x64-baseline": "1.3.10",
+        "@oven/bun-linux-x64-musl": "1.3.10",
+        "@oven/bun-linux-x64-musl-baseline": "1.3.10",
+        "@oven/bun-windows-aarch64": "1.3.10",
+        "@oven/bun-windows-x64": "1.3.10",
+        "@oven/bun-windows-x64-baseline": "1.3.10"
+      }
+    },
+    "node_modules/bun-types": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.11.tgz",
+      "integrity": "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001776",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/detect-europe-js": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
+      "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dprint-node": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/dprint-node/-/dprint-node-1.0.8.tgz",
+      "integrity": "sha512-iVKnUtYfGrYcW1ZAlfR/F59cUVL8QIhWoBJoSjkkdua/dkWIgjZfiLMeTjiB06X0ZLkQ0M2C1VbUj/CxkIf1zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^1.0.3"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.307",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/exit-x": {
+      "version": "0.2.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.2.0",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.2.0",
+        "jest-message-util": "30.2.0",
+        "jest-mock": "30.2.0",
+        "jest-util": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "license": "Unlicense"
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/graphql": {
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
+      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-ws": {
+      "version": "5.16.2",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.16.2.tgz",
+      "integrity": "sha512-E1uccsZxt/96jH/OwmLPuXMACILs76pKF2i3W861LpKBCYtGIyPQGtWLuBLkND4ox1KHns70e83PS4te50nvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=16"
+      }
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
+      "integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz",
+      "integrity": "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-standalone-pwa": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
+      "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jest": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "30.2.0",
+        "@jest/types": "30.2.0",
+        "import-local": "^3.2.0",
+        "jest-cli": "30.2.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.1.1",
+        "jest-util": "30.2.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.2.0",
+        "@jest/expect": "30.2.0",
+        "@jest/test-result": "30.2.0",
+        "@jest/types": "30.2.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "co": "^4.6.0",
+        "dedent": "^1.6.0",
+        "is-generator-fn": "^2.1.0",
+        "jest-each": "30.2.0",
+        "jest-matcher-utils": "30.2.0",
+        "jest-message-util": "30.2.0",
+        "jest-runtime": "30.2.0",
+        "jest-snapshot": "30.2.0",
+        "jest-util": "30.2.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "30.2.0",
+        "pure-rand": "^7.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "30.2.0",
+        "@jest/test-result": "30.2.0",
+        "@jest/types": "30.2.0",
+        "chalk": "^4.1.2",
+        "exit-x": "^0.2.2",
+        "import-local": "^3.2.0",
+        "jest-config": "30.2.0",
+        "jest-util": "30.2.0",
+        "jest-validate": "30.2.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/get-type": "30.1.0",
+        "@jest/pattern": "30.0.1",
+        "@jest/test-sequencer": "30.2.0",
+        "@jest/types": "30.2.0",
+        "babel-jest": "30.2.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "deepmerge": "^4.3.1",
+        "glob": "^10.3.10",
+        "graceful-fs": "^4.2.11",
+        "jest-circus": "30.2.0",
+        "jest-docblock": "30.2.0",
+        "jest-environment-node": "30.2.0",
+        "jest-regex-util": "30.0.1",
+        "jest-resolve": "30.2.0",
+        "jest-runner": "30.2.0",
+        "jest-util": "30.2.0",
+        "jest-validate": "30.2.0",
+        "micromatch": "^4.0.8",
+        "parse-json": "^5.2.0",
+        "pretty-format": "30.2.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "esbuild-register": ">=3.4.0",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "esbuild-register": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.0.1",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.2.0",
+        "chalk": "^4.1.2",
+        "jest-util": "30.2.0",
+        "pretty-format": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.2.0",
+        "@jest/fake-timers": "30.2.0",
+        "@jest/types": "30.2.0",
+        "@types/node": "*",
+        "jest-mock": "30.2.0",
+        "jest-util": "30.2.0",
+        "jest-validate": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.2.0",
+        "@types/node": "*",
+        "anymatch": "^3.1.3",
+        "fb-watchman": "^2.0.2",
+        "graceful-fs": "^4.2.11",
+        "jest-regex-util": "30.0.1",
+        "jest-util": "30.2.0",
+        "jest-worker": "30.2.0",
+        "micromatch": "^4.0.8",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.3"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "pretty-format": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.2.0",
+        "pretty-format": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.2.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "micromatch": "^4.0.8",
+        "pretty-format": "30.2.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.2.0",
+        "@types/node": "*",
+        "jest-util": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "30.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.2.0",
+        "jest-pnp-resolver": "^1.2.3",
+        "jest-util": "30.2.0",
+        "jest-validate": "30.2.0",
+        "slash": "^3.0.0",
+        "unrs-resolver": "^1.7.11"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "30.0.1",
+        "jest-snapshot": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.2.0",
+        "@jest/environment": "30.2.0",
+        "@jest/test-result": "30.2.0",
+        "@jest/transform": "30.2.0",
+        "@jest/types": "30.2.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "exit-x": "^0.2.2",
+        "graceful-fs": "^4.2.11",
+        "jest-docblock": "30.2.0",
+        "jest-environment-node": "30.2.0",
+        "jest-haste-map": "30.2.0",
+        "jest-leak-detector": "30.2.0",
+        "jest-message-util": "30.2.0",
+        "jest-resolve": "30.2.0",
+        "jest-runtime": "30.2.0",
+        "jest-util": "30.2.0",
+        "jest-watcher": "30.2.0",
+        "jest-worker": "30.2.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.2.0",
+        "@jest/fake-timers": "30.2.0",
+        "@jest/globals": "30.2.0",
+        "@jest/source-map": "30.0.1",
+        "@jest/test-result": "30.2.0",
+        "@jest/transform": "30.2.0",
+        "@jest/types": "30.2.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "cjs-module-lexer": "^2.1.0",
+        "collect-v8-coverage": "^1.0.2",
+        "glob": "^10.3.10",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.2.0",
+        "jest-message-util": "30.2.0",
+        "jest-mock": "30.2.0",
+        "jest-regex-util": "30.0.1",
+        "jest-resolve": "30.2.0",
+        "jest-snapshot": "30.2.0",
+        "jest-util": "30.2.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-snapshot": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@babel/generator": "^7.27.5",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1",
+        "@babel/types": "^7.27.3",
+        "@jest/expect-utils": "30.2.0",
+        "@jest/get-type": "30.1.0",
+        "@jest/snapshot-utils": "30.2.0",
+        "@jest/transform": "30.2.0",
+        "@jest/types": "30.2.0",
+        "babel-preset-current-node-syntax": "^1.2.0",
+        "chalk": "^4.1.2",
+        "expect": "30.2.0",
+        "graceful-fs": "^4.2.11",
+        "jest-diff": "30.2.0",
+        "jest-matcher-utils": "30.2.0",
+        "jest-message-util": "30.2.0",
+        "jest-util": "30.2.0",
+        "pretty-format": "30.2.0",
+        "semver": "^7.7.2",
+        "synckit": "^0.11.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.2.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.2.0",
+        "camelcase": "^6.3.0",
+        "chalk": "^4.1.2",
+        "leven": "^3.1.0",
+        "pretty-format": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "30.2.0",
+        "@jest/types": "30.2.0",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "jest-util": "30.2.0",
+        "string-length": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@ungap/structured-clone": "^1.3.0",
+        "jest-util": "30.2.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/js-base64": {
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
+      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/light-bolt11-decoder": {
+      "version": "3.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "@scure/base": "1.1.1"
+      }
+    },
+    "node_modules/light-bolt11-decoder/node_modules/@scure/base": {
+      "version": "1.1.1",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/micro-packed": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/micro-packed/-/micro-packed-0.7.3.tgz",
+      "integrity": "sha512-2Milxs+WNC00TRlem41oRswvw31146GiSaoCT7s3Xi2gMUglW5QBeqlQaZeHr5tJx9nm3i57LNXPqxOOaWtTYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nice-grpc": {
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/nice-grpc/-/nice-grpc-2.1.14.tgz",
+      "integrity": "sha512-GK9pKNxlvnU5FAdaw7i2FFuR9CqBspcE+if2tqnKXBcE0R8525wj4BZvfcwj7FjvqbssqKxRHt2nwedalbJlww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.0",
+        "abort-controller-x": "^0.4.0",
+        "nice-grpc-common": "^2.0.2"
+      }
+    },
+    "node_modules/nice-grpc-client-middleware-retry": {
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/nice-grpc-client-middleware-retry/-/nice-grpc-client-middleware-retry-3.1.13.tgz",
+      "integrity": "sha512-Q9I/wm5lYkDTveKFirrTHBkBY137yavXZ4xQDXTPIycUp7aLXD8xPTHFhqtAFWUw05aS91uffZZRgdv3HS0y/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller-x": "^0.4.0",
+        "nice-grpc-common": "^2.0.2"
+      }
+    },
+    "node_modules/nice-grpc-common": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/nice-grpc-common/-/nice-grpc-common-2.0.2.tgz",
+      "integrity": "sha512-7RNWbls5kAL1QVUOXvBsv1uO0wPQK3lHv+cY1gwkTzirnG1Nop4cBJZubpgziNbaVc/bl9QJcyvsf/NQxa3rjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ts-error": "^1.0.6"
+      }
+    },
+    "node_modules/nice-grpc-opentelemetry": {
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/nice-grpc-opentelemetry/-/nice-grpc-opentelemetry-0.1.20.tgz",
+      "integrity": "sha512-dRH6lmm8OgqY21WRo9BP6cHHqIhbG5UT/INFne0qIDSlSseYc6s1+qNTE3Up0z/4zY50V8tVTOH30yyhkwNXTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.8.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0",
+        "abort-controller-x": "^0.4.0",
+        "ipaddr.js": "^2.0.1",
+        "nice-grpc-common": "^2.0.2"
+      }
+    },
+    "node_modules/nice-grpc-web": {
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/nice-grpc-web/-/nice-grpc-web-3.3.9.tgz",
+      "integrity": "sha512-CiCQLdLTux9D4try8XlHW9tHIP/uLB+aciNKErDNLUM6kzhPFaVh8q+oTkoVGOjxOacEzlOwQRRjwQETAx5lVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller-x": "^0.4.0",
+        "isomorphic-ws": "^5.0.0",
+        "js-base64": "^3.7.2",
+        "nice-grpc-common": "^2.0.2"
+      }
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.27",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ox": {
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.7.tgz",
+      "integrity": "sha512-zSQ/cfBdolj7U4++NAvH7sI+VG0T3pEohITCgcQj8KlawvTDY4vGVhDT64Atsm0d6adWfIYHDpu88iUBMMp+AQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ox/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ox/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "30.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+      "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.11.12",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.2.9"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "7.2.3",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.5",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-error": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/ts-error/-/ts-error-1.0.6.tgz",
+      "integrity": "sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ts-jest": {
+      "version": "29.4.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.8",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.7.3",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-poet": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/ts-poet/-/ts-poet-6.12.0.tgz",
+      "integrity": "sha512-xo+iRNMWqyvXpFTaOAvLPA5QAWO6TZrSUs5s4Odaya3epqofBu/fMLHEWl8jPmjhA0s9sgj9sNvF1BmaQlmQkA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dprint-node": "^1.0.8"
+      }
+    },
+    "node_modules/ts-proto": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-2.8.3.tgz",
+      "integrity": "sha512-TdXInqG+61pj/TvORqITWjvjTTsL1EZxwX49iEj89+xFAcqPT8tjChpAGQXzfcF4MJwvNiuoCEbBOKqVf3ds3g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.0.0",
+        "case-anything": "^2.1.13",
+        "ts-poet": "^6.12.0",
+        "ts-proto-descriptors": "2.0.0"
+      },
+      "bin": {
+        "protoc-gen-ts_proto": "protoc-gen-ts_proto"
+      }
+    },
+    "node_modules/ts-proto-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-proto-descriptors/-/ts-proto-descriptors-2.0.0.tgz",
+      "integrity": "sha512-wHcTH3xIv11jxgkX5OyCSFfw27agpInAd6yh89hKG6zqIXnjW9SYqSER2CVQxdPj4czeOhGagNvZBEbJPy7qkw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ua-is-frozen": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
+      "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ua-parser-js": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.9.tgz",
+      "integrity": "sha512-OsqGhxyo/wGdLSXMSJxuMGN6H4gDnKz6Fb3IBm4bxZFMnyy0sdf6MN96Ie8tC6z/btdO+Bsy8guxlvLdwT076w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "detect-europe-js": "^0.1.2",
+        "is-standalone-pwa": "^0.1.1",
+        "ua-is-frozen": "^0.1.2"
+      },
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.11.1",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+        "@unrs/resolver-binding-android-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-x64": "1.11.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uuidv7": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/uuidv7/-/uuidv7-1.2.1.tgz",
+      "integrity": "sha512-4kPkK3/XTQW9Hbm4CaqfICn+kY9LJtDVEOfgsRRra/+n2Ofg4NqzRFceAkxvQ/Ud/6BpHOPzj8cirqM7TzTN5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "uuidv7": "cli.js"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/viem": {
+      "version": "2.47.6",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.47.6.tgz",
+      "integrity": "sha512-zExmbI99NGvMdYa7fmqSTLgkwh48dmhgEqFrUgkpL4kfG4XkVefZ8dZqIKVUhZo6Uhf0FrrEXOsHm9LUyIvI2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.7",
+        "ws": "8.18.3"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zen-observable": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/zen-observable-ts": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz",
+      "integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/zen-observable": "0.8.3",
+        "zen-observable": "0.8.15"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,11 @@
       "types": "./dist/esm/src/client/FlashnetClient.d.ts",
       "import": "./dist/esm/src/client/FlashnetClient.js",
       "require": "./dist/cjs/src/client/FlashnetClient.js"
+    },
+    "./execution": {
+      "types": "./dist/esm/src/execution/index.d.ts",
+      "import": "./dist/esm/src/execution/index.js",
+      "require": "./dist/cjs/src/execution/index.js"
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -89,8 +89,8 @@
   "peerDependencies": {
     "@buildonspark/issuer-sdk": "latest",
     "@buildonspark/spark-sdk": "latest",
-    "typescript": "^5",
-    "react-native-get-random-values": ">=1.11.0"
+    "react-native-get-random-values": ">=1.11.0",
+    "typescript": "^5"
   },
   "peerDependenciesMeta": {
     "@buildonspark/spark-sdk": {
@@ -106,7 +106,8 @@
   "dependencies": {
     "bech32": "^2.0.0",
     "fast-sha256": "1.3.0",
-    "light-bolt11-decoder": "^3.2.0"
+    "light-bolt11-decoder": "^3.2.0",
+    "viem": "^2.47.6"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "test:e2e:v3": "npx tsx tests/e2e-concentrated-liquidity-sdk.ts",
     "test:e2e:all": "npm run test:e2e && npm run test:e2e:v3 && npm run test:e2e:lightning",
     "test:e2e:lightning": "npx tsx tests/e2e-lightning-pools.ts",
+    "test:e2e:execution": "bun run tests/e2e-execution.ts",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "dist"
   ],
   "scripts": {
+    "prepare": "npm run build",
     "prebuild": "rm -rf dist",
     "build": "npm run type-check && rollup -c",
     "dev": "rollup -c -w",

--- a/src/execution/abis/conductor.ts
+++ b/src/execution/abis/conductor.ts
@@ -1,0 +1,28 @@
+export const conductorAbi = [
+  {
+    type: "function",
+    name: "swap",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "tokenIn", type: "address" },
+      { name: "tokenOut", type: "address" },
+      { name: "fee", type: "uint24" },
+      { name: "amountIn", type: "uint256" },
+      { name: "minAmountOut", type: "uint256" },
+      { name: "integrator", type: "address" },
+    ],
+    outputs: [{ name: "amountOut", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "swapBTC",
+    stateMutability: "payable",
+    inputs: [
+      { name: "tokenOut", type: "address" },
+      { name: "fee", type: "uint24" },
+      { name: "minAmountOut", type: "uint256" },
+      { name: "integrator", type: "address" },
+    ],
+    outputs: [{ name: "amountOut", type: "uint256" }],
+  },
+] as const;

--- a/src/execution/abis/conductorPoolCreation.ts
+++ b/src/execution/abis/conductorPoolCreation.ts
@@ -1,0 +1,45 @@
+export const conductorPoolCreationAbi = [
+  {
+    type: "function",
+    name: "createBTCPool",
+    stateMutability: "payable",
+    inputs: [
+      {
+        name: "params",
+        type: "tuple",
+        components: [
+          { name: "token0", type: "address" },
+          { name: "token1", type: "address" },
+          { name: "fee", type: "uint24" },
+          { name: "sqrtPriceX96", type: "uint160" },
+          { name: "tickLower", type: "int24" },
+          { name: "tickUpper", type: "int24" },
+          { name: "amount0Desired", type: "uint256" },
+          { name: "amount1Desired", type: "uint256" },
+          { name: "amount0Min", type: "uint256" },
+          { name: "amount1Min", type: "uint256" },
+          { name: "hostId", type: "bytes32" },
+          { name: "feeRecipient", type: "address" },
+        ],
+      },
+      {
+        name: "tokenPermit",
+        type: "tuple",
+        components: [
+          { name: "value", type: "uint256" },
+          { name: "deadline", type: "uint256" },
+          { name: "v", type: "uint8" },
+          { name: "r", type: "bytes32" },
+          { name: "s", type: "bytes32" },
+        ],
+      },
+    ],
+    outputs: [
+      { name: "pool", type: "address" },
+      { name: "tokenId", type: "uint256" },
+      { name: "liquidity", type: "uint128" },
+      { name: "amount0", type: "uint256" },
+      { name: "amount1", type: "uint256" },
+    ],
+  },
+] as const;

--- a/src/execution/abis/erc20.ts
+++ b/src/execution/abis/erc20.ts
@@ -1,0 +1,50 @@
+export const erc20Abi = [
+  {
+    type: "function",
+    name: "symbol",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "string" }],
+  },
+  {
+    type: "function",
+    name: "name",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "string" }],
+  },
+  {
+    type: "function",
+    name: "decimals",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint8" }],
+  },
+  {
+    type: "function",
+    name: "balanceOf",
+    stateMutability: "view",
+    inputs: [{ name: "account", type: "address" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "allowance",
+    stateMutability: "view",
+    inputs: [
+      { name: "owner", type: "address" },
+      { name: "spender", type: "address" },
+    ],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "approve",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+] as const;

--- a/src/execution/abis/sparkBridge.ts
+++ b/src/execution/abis/sparkBridge.ts
@@ -1,0 +1,27 @@
+export const sparkBridgeAbi = [
+  {
+    type: "function",
+    name: "withdrawSats",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "sparkRecipient", type: "bytes" }],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "withdrawBtkn",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "tokenAddress", type: "address" },
+      { name: "amount", type: "uint256" },
+      { name: "sparkRecipient", type: "bytes" },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "tokenBySparkId",
+    stateMutability: "view",
+    inputs: [{ name: "sparkTokenId", type: "bytes32" }],
+    outputs: [{ name: "", type: "address" }],
+  },
+] as const;

--- a/src/execution/abis/uniswapV3.ts
+++ b/src/execution/abis/uniswapV3.ts
@@ -1,0 +1,52 @@
+export const uniswapV3FactoryAbi = [
+  {
+    type: "function",
+    name: "getPool",
+    stateMutability: "view",
+    inputs: [
+      { name: "tokenA", type: "address" },
+      { name: "tokenB", type: "address" },
+      { name: "fee", type: "uint24" },
+    ],
+    outputs: [{ name: "pool", type: "address" }],
+  },
+] as const;
+
+export const uniswapV3PoolAbi = [
+  {
+    type: "function",
+    name: "slot0",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [
+      { name: "sqrtPriceX96", type: "uint160" },
+      { name: "tick", type: "int24" },
+      { name: "observationIndex", type: "uint16" },
+      { name: "observationCardinality", type: "uint16" },
+      { name: "observationCardinalityNext", type: "uint16" },
+      { name: "feeProtocol", type: "uint8" },
+      { name: "unlocked", type: "bool" },
+    ],
+  },
+  {
+    type: "function",
+    name: "liquidity",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint128" }],
+  },
+  {
+    type: "function",
+    name: "token0",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "address" }],
+  },
+  {
+    type: "function",
+    name: "token1",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "address" }],
+  },
+] as const;

--- a/src/execution/bridge.ts
+++ b/src/execution/bridge.ts
@@ -1,0 +1,315 @@
+/**
+ * Spark Bridge SDK Helpers
+ *
+ * Zero-dependency calldata encoding for SparkBridge contract operations
+ * (withdrawals, token resolution) and high-level withdraw functions.
+ *
+ * @example
+ * ```typescript
+ * import { encodeWithdrawSats, queryBridgedTokenAddress } from "@flashnet/sdk";
+ *
+ * const calldata = encodeWithdrawSats(sparkRecipientHex);
+ * const tokenAddr = await queryBridgedTokenAddress(rpcUrl, bridgeAddress, sparkTokenIdHex);
+ * ```
+ */
+
+import type { ExecutionClient } from "./client";
+import type { Deposit, ExecuteResponse } from "./types";
+import type { EvmTransactionSigner } from "./conductor";
+import { fetchNonce } from "./evm";
+
+// ---------------------------------------------------------------------------
+// ABI selectors
+// ---------------------------------------------------------------------------
+
+// cast sig "withdrawSats(bytes)" → 0x3b97d7d7
+const SEL_WITHDRAW_SATS = "3b97d7d7";
+// cast sig "withdrawBtkn(address,uint256,bytes)" → 0x482c9eea
+const SEL_WITHDRAW_BTKN = "482c9eea";
+// cast sig "tokenBySparkId(bytes32)" → 0x0414ff43
+const SEL_TOKEN_BY_SPARK_ID = "0414ff43";
+
+// ---------------------------------------------------------------------------
+// ABI encoding helpers (minimal, no dependencies)
+// ---------------------------------------------------------------------------
+
+function padAddress(addr: string): string {
+  const clean = addr.startsWith("0x") ? addr.slice(2) : addr;
+  return clean.toLowerCase().padStart(64, "0");
+}
+
+function padUint256(value: bigint): string {
+  return value.toString(16).padStart(64, "0");
+}
+
+function padBytes32(hex: string): string {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  return clean.padStart(64, "0");
+}
+
+// ---------------------------------------------------------------------------
+// Raw JSON-RPC helper
+// ---------------------------------------------------------------------------
+
+let rpcIdCounter = 10000;
+
+async function ethCall(
+  rpcUrl: string,
+  to: string,
+  data: string
+): Promise<string> {
+  const resp = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: rpcIdCounter++,
+      method: "eth_call",
+      params: [{ to, data }, "latest"],
+    }),
+  });
+
+  const json = (await resp.json()) as {
+    result?: string;
+    error?: { message: string };
+  };
+  if (json.error) {
+    throw new Error(`eth_call failed: ${json.error.message}`);
+  }
+  return json.result ?? "0x";
+}
+
+// ---------------------------------------------------------------------------
+// Calldata encoding
+// ---------------------------------------------------------------------------
+
+/**
+ * Encode calldata for SparkBridge.withdrawSats(sparkRecipient).
+ *
+ * @param sparkRecipient - 33-byte compressed public key as hex (with or without 0x prefix)
+ * @returns 0x-prefixed calldata hex
+ */
+export function encodeWithdrawSats(sparkRecipient: string): string {
+  const clean = sparkRecipient.startsWith("0x")
+    ? sparkRecipient.slice(2)
+    : sparkRecipient;
+
+  // ABI encode dynamic bytes: offset (32) + length (32) + padded data
+  const offset = padUint256(32n); // offset to bytes data
+  const dataLen = padUint256(BigInt(clean.length / 2)); // byte length
+  const paddedData =
+    clean + "0".repeat((64 - (clean.length % 64)) % 64);
+
+  return "0x" + SEL_WITHDRAW_SATS + offset + dataLen + paddedData;
+}
+
+/**
+ * Encode calldata for SparkBridge.withdrawBtkn(tokenAddress, amount, sparkRecipient).
+ *
+ * @param tokenAddress - ERC20 token contract address (0x-prefixed)
+ * @param amount - Amount in token base units
+ * @param sparkRecipient - 33-byte compressed public key as hex
+ * @returns 0x-prefixed calldata hex
+ */
+export function encodeWithdrawToken(
+  tokenAddress: string,
+  amount: bigint,
+  sparkRecipient: string
+): string {
+  const cleanRecipient = sparkRecipient.startsWith("0x")
+    ? sparkRecipient.slice(2)
+    : sparkRecipient;
+
+  // address + uint256 are static; bytes is dynamic
+  const addr = padAddress(tokenAddress);
+  const amt = padUint256(amount);
+  const bytesOffset = padUint256(96n); // offset to bytes (3 * 32 = 96)
+  const dataLen = padUint256(BigInt(cleanRecipient.length / 2));
+  const paddedData =
+    cleanRecipient + "0".repeat((64 - (cleanRecipient.length % 64)) % 64);
+
+  return (
+    "0x" + SEL_WITHDRAW_BTKN + addr + amt + bytesOffset + dataLen + paddedData
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Bridge queries
+// ---------------------------------------------------------------------------
+
+/**
+ * Query the EVM token address for a bridged Spark token via SparkBridge.tokenBySparkId().
+ *
+ * @param rpcUrl - JSON-RPC endpoint URL
+ * @param bridgeAddress - SparkBridge contract address
+ * @param sparkTokenIdHex - 32-byte Spark token ID as hex
+ * @returns EVM token address, or null if not yet bridged
+ */
+export async function queryBridgedTokenAddress(
+  rpcUrl: string,
+  bridgeAddress: string,
+  sparkTokenIdHex: string
+): Promise<string | null> {
+  const calldata = "0x" + SEL_TOKEN_BY_SPARK_ID + padBytes32(sparkTokenIdHex);
+  const result = await ethCall(rpcUrl, bridgeAddress, calldata);
+
+  const clean = result.startsWith("0x") ? result.slice(2) : result;
+  if (clean.length < 64 || clean === "0".repeat(64)) {
+    return null;
+  }
+
+  const addr = "0x" + clean.slice(24, 64);
+  if (addr === "0x" + "0".repeat(40)) {
+    return null;
+  }
+  return addr;
+}
+
+/**
+ * Poll for a bridged token address until it appears or timeout.
+ *
+ * @param rpcUrl - JSON-RPC endpoint URL
+ * @param bridgeAddress - SparkBridge contract address
+ * @param sparkTokenIdHex - 32-byte Spark token ID as hex
+ * @param timeoutMs - Maximum wait time (default 20s)
+ * @param pollIntervalMs - Poll interval (default 500ms)
+ * @returns EVM token address, or null if not found within timeout
+ */
+export async function waitForBridgedTokenAddress(
+  rpcUrl: string,
+  bridgeAddress: string,
+  sparkTokenIdHex: string,
+  timeoutMs: number = 20_000,
+  pollIntervalMs: number = 500
+): Promise<string | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const addr = await queryBridgedTokenAddress(
+      rpcUrl,
+      bridgeAddress,
+      sparkTokenIdHex
+    );
+    if (addr) return addr;
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// High-level withdraw functions
+// ---------------------------------------------------------------------------
+
+/** Configuration for bridge operations. */
+export interface BridgeConfig {
+  /** SparkBridge contract address (0x-prefixed). */
+  bridgeAddress: string;
+  /** JSON-RPC endpoint for EVM read queries. */
+  rpcUrl: string;
+  /** Chain ID of the Flashnet EVM. */
+  chainId: number;
+}
+
+/** Result of a withdraw operation. */
+export interface WithdrawResult {
+  submissionId: string;
+  intentId: string;
+  status: string;
+}
+
+/**
+ * Withdraw native BTC from EVM back to Spark.
+ *
+ * Encodes a SparkBridge.withdrawSats() call, signs it, and submits
+ * as an execute intent. The caller must have sufficient EVM balance.
+ *
+ * @param client - Authenticated ExecutionClient
+ * @param config - Bridge and chain configuration
+ * @param sparkRecipient - 33-byte compressed public key hex of the Spark recipient
+ * @param amount - Amount in wei to withdraw
+ * @param evmSigner - Signs the withdrawal transaction
+ * @returns Submission result from the execution gateway
+ */
+export async function withdrawSats(
+  client: ExecutionClient,
+  config: BridgeConfig,
+  sparkRecipient: string,
+  amount: bigint,
+  evmSigner: EvmTransactionSigner
+): Promise<WithdrawResult> {
+  const calldata = encodeWithdrawSats(sparkRecipient);
+  const senderAddress = await evmSigner.getAddress();
+  const nonce = await fetchNonce(config.rpcUrl, senderAddress);
+
+  const signedTx = await evmSigner.signTransaction({
+    to: config.bridgeAddress,
+    data: calldata,
+    value: amount,
+    chainId: config.chainId,
+    nonce,
+    gasLimit: 200_000n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+  });
+
+  const response: ExecuteResponse = await client.submitExecute({
+    chainId: config.chainId,
+    deposits: [],
+    signedTx,
+  });
+
+  return {
+    submissionId: response.submissionId,
+    intentId: response.intentId,
+    status: response.status,
+  };
+}
+
+/**
+ * Withdraw an ERC20 token from EVM back to Spark.
+ *
+ * Encodes a SparkBridge.withdrawBtkn() call, signs it, and submits
+ * as an execute intent.
+ *
+ * @param client - Authenticated ExecutionClient
+ * @param config - Bridge and chain configuration
+ * @param tokenAddress - ERC20 token contract address
+ * @param amount - Amount in token base units
+ * @param sparkRecipient - 33-byte compressed public key hex of the Spark recipient
+ * @param evmSigner - Signs the withdrawal transaction
+ * @returns Submission result from the execution gateway
+ */
+export async function withdrawToken(
+  client: ExecutionClient,
+  config: BridgeConfig,
+  tokenAddress: string,
+  amount: bigint,
+  sparkRecipient: string,
+  evmSigner: EvmTransactionSigner
+): Promise<WithdrawResult> {
+  const calldata = encodeWithdrawToken(tokenAddress, amount, sparkRecipient);
+  const senderAddress = await evmSigner.getAddress();
+  const nonce = await fetchNonce(config.rpcUrl, senderAddress);
+
+  const signedTx = await evmSigner.signTransaction({
+    to: config.bridgeAddress,
+    data: calldata,
+    value: 0n,
+    chainId: config.chainId,
+    nonce,
+    gasLimit: 200_000n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+  });
+
+  const response: ExecuteResponse = await client.submitExecute({
+    chainId: config.chainId,
+    deposits: [],
+    signedTx,
+  });
+
+  return {
+    submissionId: response.submissionId,
+    intentId: response.intentId,
+    status: response.status,
+  };
+}

--- a/src/execution/bridge.ts
+++ b/src/execution/bridge.ts
@@ -25,6 +25,21 @@ import type { EvmTransactionSigner } from "./conductor";
 import { fetchNonce } from "./evm";
 import { getClient } from "./rpc";
 
+/**
+ * Conversion factor from satoshis to wei on Flashnet's EVM.
+ *
+ * On Flashnet, BTC is the native EVM currency (i.e. BTC ≡ ETH), so
+ * 1 sat = 10^-8 BTC and 1 wei = 10^-18 BTC, giving 1 sat = 10^10 wei.
+ *
+ * The SparkBridge contract interprets `msg.value` in wei, so any amount
+ * denominated in sats must be multiplied by this constant before being
+ * set as the transaction value.
+ *
+ * Mirrors `WEI_PER_SAT` in the Rust bridge implementation
+ * (`crates/flashnet-revm/src/bridge.rs`).
+ */
+const WEI_PER_SAT = 10_000_000_000n; // 10^10
+
 // Calldata encoding
 
 /**
@@ -127,7 +142,13 @@ export interface WithdrawResult {
 }
 
 /**
- * Withdraw native BTC from EVM back to Spark.
+ * Withdraw native BTC (sats) from EVM back to Spark.
+ *
+ * @param amount - Amount in **satoshis**. Internally converted to wei
+ *   (× {@link WEI_PER_SAT}) because the SparkBridge contract reads
+ *   `msg.value` in wei. Without this conversion the contract would see
+ *   a near-zero value — e.g. 1 000 sats sent as 1 000 wei instead of
+ *   the correct 10 000 000 000 000 wei (10^13).
  */
 export async function withdrawSats(
   client: ExecutionClient,
@@ -143,7 +164,7 @@ export async function withdrawSats(
   const signedTx = await evmSigner.signTransaction({
     to: config.bridgeAddress,
     data: calldata,
-    value: amount,
+    value: amount * WEI_PER_SAT,
     chainId: config.chainId,
     nonce,
     gasLimit: 200_000n,

--- a/src/execution/bridge.ts
+++ b/src/execution/bridge.ts
@@ -29,9 +29,7 @@ import type { ExecuteResponse } from "./types";
 import type { EvmTransactionSigner } from "./conductor";
 import { fetchNonce } from "./evm";
 
-// ---------------------------------------------------------------------------
 // Client cache
-// ---------------------------------------------------------------------------
 
 const clientCache = new Map<string, PublicClient<Transport, Chain | undefined>>();
 
@@ -44,9 +42,7 @@ function getClient(rpcUrl: string): PublicClient<Transport, Chain | undefined> {
   return client;
 }
 
-// ---------------------------------------------------------------------------
 // Calldata encoding
-// ---------------------------------------------------------------------------
 
 /**
  * Encode calldata for SparkBridge.withdrawSats(sparkRecipient).
@@ -83,9 +79,7 @@ export function encodeWithdrawToken(
   });
 }
 
-// ---------------------------------------------------------------------------
 // Bridge queries
-// ---------------------------------------------------------------------------
 
 /**
  * Query the EVM token address for a bridged Spark token.
@@ -135,9 +129,7 @@ export async function waitForBridgedTokenAddress(
   return null;
 }
 
-// ---------------------------------------------------------------------------
 // High-level withdraw functions
-// ---------------------------------------------------------------------------
 
 export interface BridgeConfig {
   bridgeAddress: string;

--- a/src/execution/bridge.ts
+++ b/src/execution/bridge.ts
@@ -1,8 +1,8 @@
 /**
  * Spark Bridge SDK Helpers
  *
- * Zero-dependency calldata encoding for SparkBridge contract operations
- * (withdrawals, token resolution) and high-level withdraw functions.
+ * Calldata encoding for SparkBridge contract operations (withdrawals,
+ * token resolution) and high-level withdraw functions using viem.
  *
  * @example
  * ```typescript
@@ -13,70 +13,35 @@
  * ```
  */
 
+import {
+  createPublicClient,
+  http,
+  encodeFunctionData,
+  zeroAddress,
+  type Address,
+  type PublicClient,
+  type Transport,
+  type Chain,
+} from "viem";
+import { sparkBridgeAbi } from "./abis/sparkBridge";
 import type { ExecutionClient } from "./client";
-import type { Deposit, ExecuteResponse } from "./types";
+import type { ExecuteResponse } from "./types";
 import type { EvmTransactionSigner } from "./conductor";
 import { fetchNonce } from "./evm";
 
 // ---------------------------------------------------------------------------
-// ABI selectors
+// Client cache
 // ---------------------------------------------------------------------------
 
-// cast sig "withdrawSats(bytes)" → 0x3b97d7d7
-const SEL_WITHDRAW_SATS = "3b97d7d7";
-// cast sig "withdrawBtkn(address,uint256,bytes)" → 0x482c9eea
-const SEL_WITHDRAW_BTKN = "482c9eea";
-// cast sig "tokenBySparkId(bytes32)" → 0x0414ff43
-const SEL_TOKEN_BY_SPARK_ID = "0414ff43";
+const clientCache = new Map<string, PublicClient<Transport, Chain | undefined>>();
 
-// ---------------------------------------------------------------------------
-// ABI encoding helpers (minimal, no dependencies)
-// ---------------------------------------------------------------------------
-
-function padAddress(addr: string): string {
-  const clean = addr.startsWith("0x") ? addr.slice(2) : addr;
-  return clean.toLowerCase().padStart(64, "0");
-}
-
-function padUint256(value: bigint): string {
-  return value.toString(16).padStart(64, "0");
-}
-
-function padBytes32(hex: string): string {
-  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
-  return clean.padStart(64, "0");
-}
-
-// ---------------------------------------------------------------------------
-// Raw JSON-RPC helper
-// ---------------------------------------------------------------------------
-
-let rpcIdCounter = 10000;
-
-async function ethCall(
-  rpcUrl: string,
-  to: string,
-  data: string
-): Promise<string> {
-  const resp = await fetch(rpcUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      id: rpcIdCounter++,
-      method: "eth_call",
-      params: [{ to, data }, "latest"],
-    }),
-  });
-
-  const json = (await resp.json()) as {
-    result?: string;
-    error?: { message: string };
-  };
-  if (json.error) {
-    throw new Error(`eth_call failed: ${json.error.message}`);
+function getClient(rpcUrl: string): PublicClient<Transport, Chain | undefined> {
+  let client = clientCache.get(rpcUrl);
+  if (!client) {
+    client = createPublicClient({ transport: http(rpcUrl) });
+    clientCache.set(rpcUrl, client);
   }
-  return json.result ?? "0x";
+  return client;
 }
 
 // ---------------------------------------------------------------------------
@@ -90,47 +55,32 @@ async function ethCall(
  * @returns 0x-prefixed calldata hex
  */
 export function encodeWithdrawSats(sparkRecipient: string): string {
-  const clean = sparkRecipient.startsWith("0x")
-    ? sparkRecipient.slice(2)
-    : sparkRecipient;
-
-  // ABI encode dynamic bytes: offset (32) + length (32) + padded data
-  const offset = padUint256(32n); // offset to bytes data
-  const dataLen = padUint256(BigInt(clean.length / 2)); // byte length
-  const paddedData =
-    clean + "0".repeat((64 - (clean.length % 64)) % 64);
-
-  return "0x" + SEL_WITHDRAW_SATS + offset + dataLen + paddedData;
+  const hex = sparkRecipient.startsWith("0x")
+    ? sparkRecipient
+    : `0x${sparkRecipient}`;
+  return encodeFunctionData({
+    abi: sparkBridgeAbi,
+    functionName: "withdrawSats",
+    args: [hex as `0x${string}`],
+  });
 }
 
 /**
  * Encode calldata for SparkBridge.withdrawBtkn(tokenAddress, amount, sparkRecipient).
- *
- * @param tokenAddress - ERC20 token contract address (0x-prefixed)
- * @param amount - Amount in token base units
- * @param sparkRecipient - 33-byte compressed public key as hex
- * @returns 0x-prefixed calldata hex
  */
 export function encodeWithdrawToken(
   tokenAddress: string,
   amount: bigint,
   sparkRecipient: string
 ): string {
-  const cleanRecipient = sparkRecipient.startsWith("0x")
-    ? sparkRecipient.slice(2)
-    : sparkRecipient;
-
-  // address + uint256 are static; bytes is dynamic
-  const addr = padAddress(tokenAddress);
-  const amt = padUint256(amount);
-  const bytesOffset = padUint256(96n); // offset to bytes (3 * 32 = 96)
-  const dataLen = padUint256(BigInt(cleanRecipient.length / 2));
-  const paddedData =
-    cleanRecipient + "0".repeat((64 - (cleanRecipient.length % 64)) % 64);
-
-  return (
-    "0x" + SEL_WITHDRAW_BTKN + addr + amt + bytesOffset + dataLen + paddedData
-  );
+  const hex = sparkRecipient.startsWith("0x")
+    ? sparkRecipient
+    : `0x${sparkRecipient}`;
+  return encodeFunctionData({
+    abi: sparkBridgeAbi,
+    functionName: "withdrawBtkn",
+    args: [tokenAddress as Address, amount, hex as `0x${string}`],
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -138,42 +88,32 @@ export function encodeWithdrawToken(
 // ---------------------------------------------------------------------------
 
 /**
- * Query the EVM token address for a bridged Spark token via SparkBridge.tokenBySparkId().
- *
- * @param rpcUrl - JSON-RPC endpoint URL
- * @param bridgeAddress - SparkBridge contract address
- * @param sparkTokenIdHex - 32-byte Spark token ID as hex
- * @returns EVM token address, or null if not yet bridged
+ * Query the EVM token address for a bridged Spark token.
+ * Returns null if not yet bridged.
  */
 export async function queryBridgedTokenAddress(
   rpcUrl: string,
   bridgeAddress: string,
   sparkTokenIdHex: string
 ): Promise<string | null> {
-  const calldata = "0x" + SEL_TOKEN_BY_SPARK_ID + padBytes32(sparkTokenIdHex);
-  const result = await ethCall(rpcUrl, bridgeAddress, calldata);
+  const client = getClient(rpcUrl);
+  const hex = sparkTokenIdHex.startsWith("0x")
+    ? sparkTokenIdHex
+    : `0x${sparkTokenIdHex}`;
 
-  const clean = result.startsWith("0x") ? result.slice(2) : result;
-  if (clean.length < 64 || clean === "0".repeat(64)) {
-    return null;
-  }
+  const result = await client.readContract({
+    address: bridgeAddress as Address,
+    abi: sparkBridgeAbi,
+    functionName: "tokenBySparkId",
+    args: [hex as `0x${string}`],
+  });
 
-  const addr = "0x" + clean.slice(24, 64);
-  if (addr === "0x" + "0".repeat(40)) {
-    return null;
-  }
-  return addr;
+  if (result === zeroAddress) return null;
+  return result;
 }
 
 /**
  * Poll for a bridged token address until it appears or timeout.
- *
- * @param rpcUrl - JSON-RPC endpoint URL
- * @param bridgeAddress - SparkBridge contract address
- * @param sparkTokenIdHex - 32-byte Spark token ID as hex
- * @param timeoutMs - Maximum wait time (default 20s)
- * @param pollIntervalMs - Poll interval (default 500ms)
- * @returns EVM token address, or null if not found within timeout
  */
 export async function waitForBridgedTokenAddress(
   rpcUrl: string,
@@ -199,17 +139,12 @@ export async function waitForBridgedTokenAddress(
 // High-level withdraw functions
 // ---------------------------------------------------------------------------
 
-/** Configuration for bridge operations. */
 export interface BridgeConfig {
-  /** SparkBridge contract address (0x-prefixed). */
   bridgeAddress: string;
-  /** JSON-RPC endpoint for EVM read queries. */
   rpcUrl: string;
-  /** Chain ID of the Flashnet EVM. */
   chainId: number;
 }
 
-/** Result of a withdraw operation. */
 export interface WithdrawResult {
   submissionId: string;
   intentId: string;
@@ -218,16 +153,6 @@ export interface WithdrawResult {
 
 /**
  * Withdraw native BTC from EVM back to Spark.
- *
- * Encodes a SparkBridge.withdrawSats() call, signs it, and submits
- * as an execute intent. The caller must have sufficient EVM balance.
- *
- * @param client - Authenticated ExecutionClient
- * @param config - Bridge and chain configuration
- * @param sparkRecipient - 33-byte compressed public key hex of the Spark recipient
- * @param amount - Amount in wei to withdraw
- * @param evmSigner - Signs the withdrawal transaction
- * @returns Submission result from the execution gateway
  */
 export async function withdrawSats(
   client: ExecutionClient,
@@ -266,17 +191,6 @@ export async function withdrawSats(
 
 /**
  * Withdraw an ERC20 token from EVM back to Spark.
- *
- * Encodes a SparkBridge.withdrawBtkn() call, signs it, and submits
- * as an execute intent.
- *
- * @param client - Authenticated ExecutionClient
- * @param config - Bridge and chain configuration
- * @param tokenAddress - ERC20 token contract address
- * @param amount - Amount in token base units
- * @param sparkRecipient - 33-byte compressed public key hex of the Spark recipient
- * @param evmSigner - Signs the withdrawal transaction
- * @returns Submission result from the execution gateway
  */
 export async function withdrawToken(
   client: ExecutionClient,

--- a/src/execution/bridge.ts
+++ b/src/execution/bridge.ts
@@ -14,33 +14,16 @@
  */
 
 import {
-  createPublicClient,
-  http,
   encodeFunctionData,
   zeroAddress,
   type Address,
-  type PublicClient,
-  type Transport,
-  type Chain,
 } from "viem";
 import { sparkBridgeAbi } from "./abis/sparkBridge";
 import type { ExecutionClient } from "./client";
 import type { ExecuteResponse } from "./types";
 import type { EvmTransactionSigner } from "./conductor";
 import { fetchNonce } from "./evm";
-
-// Client cache
-
-const clientCache = new Map<string, PublicClient<Transport, Chain | undefined>>();
-
-function getClient(rpcUrl: string): PublicClient<Transport, Chain | undefined> {
-  let client = clientCache.get(rpcUrl);
-  if (!client) {
-    client = createPublicClient({ transport: http(rpcUrl) });
-    clientCache.set(rpcUrl, client);
-  }
-  return client;
-}
+import { getClient } from "./rpc";
 
 // Calldata encoding
 

--- a/src/execution/client.ts
+++ b/src/execution/client.ts
@@ -9,6 +9,7 @@
  * this client talks to flashnet-execution's gateway.
  */
 
+import { keccak256 as viemKeccak256 } from "viem";
 import type {
   CanonicalIntentAction,
   CanonicalIntentMessage,
@@ -123,8 +124,11 @@ export class ExecutionClient {
       validateDeposits(params.deposits);
     }
 
+    const txHex = params.signedTx.startsWith("0x")
+      ? params.signedTx
+      : `0x${params.signedTx}`;
     const txHash =
-      params.signedTxHash ?? keccak256Hex(hexToBytes(params.signedTx));
+      params.signedTxHash ?? viemKeccak256(txHex as `0x${string}`);
 
     const action: CanonicalIntentAction = {
       type: "execute",
@@ -285,136 +289,4 @@ function validateDeposits(deposits: Deposit[]): void {
       );
     }
   }
-}
-
-/** Convert a hex string (with or without 0x prefix) to Uint8Array. */
-function hexToBytes(hex: string): Uint8Array {
-  const clean =
-    hex.startsWith("0x") || hex.startsWith("0X") ? hex.slice(2) : hex;
-  if (clean.length % 2 !== 0) {
-    throw new Error(
-      `hexToBytes: input has odd length (${clean.length} hex chars)`
-    );
-  }
-  if (clean.length > 0 && !/^[0-9a-fA-F]+$/.test(clean)) {
-    throw new Error("hexToBytes: input contains invalid hex characters");
-  }
-  const bytes = new Uint8Array(clean.length / 2);
-  for (let i = 0; i < bytes.length; i++) {
-    bytes[i] = Number.parseInt(clean.substring(i * 2, i * 2 + 2), 16);
-  }
-  return bytes;
-}
-
-function bytesToHex(bytes: Uint8Array): string {
-  let hex = "";
-  for (const b of bytes) {
-    hex += b.toString(16).padStart(2, "0");
-  }
-  return hex;
-}
-
-/** Compute keccak256 hash of bytes, returning 0x-prefixed lowercase hex. */
-function keccak256Hex(data: Uint8Array): string {
-  return `0x${bytesToHex(keccak256(data))}`;
-}
-
-// ---------------------------------------------------------------------------
-// Minimal Keccak-256 (Ethereum hash)
-// Public domain reference adapted for strict TypeScript.
-// ---------------------------------------------------------------------------
-
-const RC: bigint[] = [
-  0x0000000000000001n, 0x0000000000008082n, 0x800000000000808an,
-  0x8000000080008000n, 0x000000000000808bn, 0x0000000080000001n,
-  0x8000000080008081n, 0x8000000000008009n, 0x000000000000008an,
-  0x0000000000000088n, 0x0000000080008009n, 0x000000008000000an,
-  0x000000008000808bn, 0x800000000000008bn, 0x8000000000008089n,
-  0x8000000000008003n, 0x8000000000008002n, 0x8000000000000080n,
-  0x000000000000800an, 0x800000008000000an, 0x8000000080008081n,
-  0x8000000000008080n, 0x0000000080000001n, 0x8000000080008008n,
-];
-const ROTC: number[] = [
-  1, 3, 6, 10, 15, 21, 28, 36, 45, 55, 2, 14, 27, 41, 56, 8, 25, 43, 62, 18,
-  39, 61, 20, 44,
-];
-const PI: number[] = [
-  10, 7, 11, 17, 18, 3, 5, 16, 8, 21, 24, 4, 15, 23, 19, 13, 12, 2, 20, 14,
-  22, 9, 6, 1,
-];
-const M64 = 0xffffffffffffffffn;
-
-function keccakF(s: bigint[]): void {
-  for (let round = 0; round < 24; round++) {
-    const c0 = s[0]! ^ s[5]! ^ s[10]! ^ s[15]! ^ s[20]!;
-    const c1 = s[1]! ^ s[6]! ^ s[11]! ^ s[16]! ^ s[21]!;
-    const c2 = s[2]! ^ s[7]! ^ s[12]! ^ s[17]! ^ s[22]!;
-    const c3 = s[3]! ^ s[8]! ^ s[13]! ^ s[18]! ^ s[23]!;
-    const c4 = s[4]! ^ s[9]! ^ s[14]! ^ s[19]! ^ s[24]!;
-    const c = [c0, c1, c2, c3, c4];
-    for (let x = 0; x < 5; x++) {
-      const next = c[(x + 1) % 5]!;
-      const d = c[(x + 4) % 5]! ^ (((next << 1n) | (next >> 63n)) & M64);
-      for (let y = 0; y < 25; y += 5) s[y + x] = (s[y + x]! ^ d) & M64;
-    }
-    let last = s[1]!;
-    for (let i = 0; i < 24; i++) {
-      const j = PI[i]!;
-      const temp = s[j]!;
-      const r = BigInt(ROTC[i]!);
-      s[j] = ((last << r) | (last >> (64n - r))) & M64;
-      last = temp;
-    }
-    for (let y = 0; y < 25; y += 5) {
-      const t0 = s[y]!,
-        t1 = s[y + 1]!,
-        t2 = s[y + 2]!,
-        t3 = s[y + 3]!,
-        t4 = s[y + 4]!;
-      s[y] = (t0 ^ (~t1 & t2)) & M64;
-      s[y + 1] = (t1 ^ (~t2 & t3)) & M64;
-      s[y + 2] = (t2 ^ (~t3 & t4)) & M64;
-      s[y + 3] = (t3 ^ (~t4 & t0)) & M64;
-      s[y + 4] = (t4 ^ (~t0 & t1)) & M64;
-    }
-    s[0] = (s[0]! ^ RC[round]!) & M64;
-  }
-}
-
-function keccak256(data: Uint8Array): Uint8Array {
-  const rate = 136;
-  const s: bigint[] = new Array<bigint>(25).fill(0n);
-
-  let offset = 0;
-  while (offset + rate <= data.length) {
-    for (let i = 0; i < rate; i += 8) {
-      let lane = 0n;
-      for (let b = 0; b < 8; b++)
-        lane |= BigInt(data[offset + i + b]!) << BigInt(b * 8);
-      s[i >> 3] = s[i >> 3]! ^ lane;
-    }
-    keccakF(s);
-    offset += rate;
-  }
-
-  const padded = new Uint8Array(rate);
-  const remaining = data.length - offset;
-  for (let i = 0; i < remaining; i++) padded[i] = data[offset + i]!;
-  padded[remaining] = 0x01;
-  padded[rate - 1] = padded[rate - 1]! | 0x80;
-
-  for (let i = 0; i < rate; i += 8) {
-    let lane = 0n;
-    for (let b = 0; b < 8; b++) lane |= BigInt(padded[i + b]!) << BigInt(b * 8);
-    s[i >> 3] = s[i >> 3]! ^ lane;
-  }
-  keccakF(s);
-
-  const out = new Uint8Array(32);
-  for (let i = 0; i < 4; i++) {
-    const lane = s[i]!;
-    for (let b = 0; b < 8; b++)
-      out[i * 8 + b] = Number((lane >> BigInt(b * 8)) & 0xffn);
-  }
-  return out;
 }

--- a/src/execution/client.ts
+++ b/src/execution/client.ts
@@ -1,0 +1,399 @@
+/**
+ * Flashnet Execution Client
+ *
+ * Client for interacting with the Flashnet execution gateway.
+ * Handles authentication, intent construction, signing, and submission.
+ *
+ * This is the new execution-layer client, separate from the legacy AMM client
+ * (FlashnetClient). The legacy client talks to flashnet-services/settlement;
+ * this client talks to flashnet-execution's gateway.
+ */
+
+import type {
+  CanonicalIntentAction,
+  CanonicalIntentMessage,
+  CanonicalTransferEntry,
+  Deposit,
+  DepositIntentParams,
+  ExecuteIntentParams,
+  ExecuteResponse,
+  ExecutionClientConfig,
+  ExecutionSigner,
+} from "./types";
+
+/**
+ * Client for the Flashnet execution gateway.
+ *
+ * Supports multi-deposit intents (deposit-only and deposit-and-execute).
+ *
+ * @example
+ * ```typescript
+ * import { ExecutionClient } from "@flashnet/sdk/execution";
+ *
+ * const client = new ExecutionClient({
+ *   gatewayUrl: "http://localhost:8080",
+ * }, signer);
+ *
+ * await client.authenticate();
+ *
+ * const response = await client.submitDeposit({
+ *   chainId: 1337,
+ *   deposits: [
+ *     { sparkTransferId: "aabb...", amount: 100000, asset: { type: "btc" } },
+ *   ],
+ *   recipient: "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD18",
+ * });
+ * ```
+ */
+export class ExecutionClient {
+  private readonly gatewayUrl: string;
+  private readonly signer: ExecutionSigner;
+  private accessToken: string | null = null;
+
+  constructor(config: ExecutionClientConfig, signer: ExecutionSigner) {
+    this.gatewayUrl = config.gatewayUrl.replace(/\/+$/, "");
+    this.signer = signer;
+  }
+
+  /**
+   * Authenticate with the execution gateway via challenge-response.
+   * Must be called before submitting intents.
+   */
+  async authenticate(): Promise<string> {
+    const publicKey = await this.signer.getPublicKey();
+
+    const challengeResp = await this.post<{
+      challenge: string;
+      challengeString: string;
+    }>("/api/v1/auth/challenge", { publicKey });
+
+    const challengeString =
+      challengeResp.challengeString || challengeResp.challenge;
+    if (!challengeString) {
+      throw new Error("Gateway challenge response missing challengeString");
+    }
+
+    const signature = await this.signer.signMessage(challengeString);
+
+    const verifyResp = await this.post<{ accessToken: string }>(
+      "/api/v1/auth/verify",
+      { publicKey, signature }
+    );
+
+    if (!verifyResp.accessToken) {
+      throw new Error("Gateway verify response missing accessToken");
+    }
+
+    this.accessToken = verifyResp.accessToken;
+    return this.accessToken;
+  }
+
+  /**
+   * Submit a deposit-only intent.
+   * Credits the deposited funds to the specified recipient address.
+   */
+  async submitDeposit(params: DepositIntentParams): Promise<ExecuteResponse> {
+    this.requireAuth();
+    validateDeposits(params.deposits);
+
+    const action: CanonicalIntentAction = {
+      type: "deposit",
+      recipient: params.recipient.toLowerCase(),
+    };
+
+    return this.submitIntent(params.chainId, params.deposits, action, {
+      recipient: params.recipient,
+    });
+  }
+
+  /**
+   * Submit a deposit-and-execute intent.
+   * Deposits are credited to the recovered signer of the EVM transaction,
+   * and the transaction is executed atomically in the same block.
+   *
+   * @param params.signedTxHash - Pre-computed keccak256 hash of the signed tx
+   *   (0x-prefixed hex). If not provided, the client computes it from signedTx
+   *   using the built-in keccak256 implementation.
+   */
+  async submitExecute(
+    params: ExecuteIntentParams & { signedTxHash?: string }
+  ): Promise<ExecuteResponse> {
+    this.requireAuth();
+    validateDeposits(params.deposits);
+
+    const txHash =
+      params.signedTxHash ?? keccak256Hex(hexToBytes(params.signedTx));
+
+    const action: CanonicalIntentAction = {
+      type: "execute",
+      signedTxHash: txHash,
+    };
+
+    return this.submitIntent(params.chainId, params.deposits, action, {
+      evmTransaction: params.signedTx,
+    });
+  }
+
+  /**
+   * Check if the gateway is healthy.
+   */
+  async health(): Promise<boolean> {
+    try {
+      const resp = await fetch(`${this.gatewayUrl}/api/v1/health`);
+      if (!resp.ok) return false;
+      const body = (await resp.json()) as { status?: string };
+      return body.status === "ok";
+    } catch {
+      return false;
+    }
+  }
+
+  /** Returns the current access token, or null if not authenticated. */
+  getAccessToken(): string | null {
+    return this.accessToken;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private
+  // ---------------------------------------------------------------------------
+
+  private async submitIntent(
+    chainId: number,
+    deposits: Deposit[],
+    action: CanonicalIntentAction,
+    requestAction: { recipient?: string; evmTransaction?: string }
+  ): Promise<ExecuteResponse> {
+    const nonce = crypto.randomUUID();
+
+    const transfers: CanonicalTransferEntry[] = deposits.map((d) => {
+      const entry: CanonicalTransferEntry = {
+        transferId: d.sparkTransferId,
+        amountSats: d.amount,
+        assetType: d.asset.type === "btc" ? "NativeSats" : "BridgedToken",
+      };
+      if (d.asset.type === "token") {
+        entry.tokenId = d.asset.tokenId;
+      }
+      return entry;
+    });
+
+    const canonicalMessage: CanonicalIntentMessage = {
+      chainId,
+      transfers,
+      action,
+      nonce,
+    };
+
+    const messageJson = JSON.stringify(canonicalMessage);
+    const signature = await this.signer.signMessage(messageJson);
+
+    const body: Record<string, unknown> = {
+      chainId,
+      deposits: deposits.map((d) => ({
+        sparkTransferId: d.sparkTransferId,
+        asset: d.asset,
+        amount: d.amount,
+      })),
+      signature,
+      nonce,
+    };
+
+    if (requestAction.recipient) {
+      body.recipient = requestAction.recipient;
+    }
+    if (requestAction.evmTransaction) {
+      body.evmTransaction = requestAction.evmTransaction;
+    }
+
+    return this.post<ExecuteResponse>("/api/v1/execute", body, {
+      Authorization: `Bearer ${this.accessToken}`,
+    });
+  }
+
+  private requireAuth(): void {
+    if (!this.accessToken) {
+      throw new Error(
+        "Not authenticated. Call authenticate() before submitting intents."
+      );
+    }
+  }
+
+  private async post<T>(
+    path: string,
+    body: unknown,
+    headers: Record<string, string> = {}
+  ): Promise<T> {
+    const resp = await fetch(`${this.gatewayUrl}${path}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...headers,
+      },
+      body: JSON.stringify(body),
+    });
+
+    const text = await resp.text();
+    if (!resp.ok) {
+      throw new Error(
+        `Execution gateway request failed (${resp.status}): ${text}`
+      );
+    }
+
+    try {
+      return JSON.parse(text) as T;
+    } catch {
+      throw new Error(`Execution gateway response is not valid JSON: ${text}`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function validateDeposits(deposits: Deposit[]): void {
+  if (deposits.length === 0) {
+    throw new Error("deposits must contain at least one entry");
+  }
+  for (let i = 0; i < deposits.length; i++) {
+    const d = deposits[i]!;
+    if (!d.sparkTransferId || d.sparkTransferId.trim() === "") {
+      throw new Error(`deposits[${i}].sparkTransferId is required`);
+    }
+    if (d.amount <= 0) {
+      throw new Error(`deposits[${i}].amount must be greater than zero`);
+    }
+    if (
+      d.asset.type === "token" &&
+      (!d.asset.tokenId || d.asset.tokenId.trim() === "")
+    ) {
+      throw new Error(
+        `deposits[${i}].asset.tokenId is required for token deposits`
+      );
+    }
+  }
+}
+
+/** Convert a hex string (with or without 0x prefix) to Uint8Array. */
+function hexToBytes(hex: string): Uint8Array {
+  const clean =
+    hex.startsWith("0x") || hex.startsWith("0X") ? hex.slice(2) : hex;
+  const bytes = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = Number.parseInt(clean.substring(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  let hex = "";
+  for (const b of bytes) {
+    hex += b.toString(16).padStart(2, "0");
+  }
+  return hex;
+}
+
+/** Compute keccak256 hash of bytes, returning 0x-prefixed lowercase hex. */
+function keccak256Hex(data: Uint8Array): string {
+  return `0x${bytesToHex(keccak256(data))}`;
+}
+
+// ---------------------------------------------------------------------------
+// Minimal Keccak-256 (Ethereum hash)
+// Public domain reference adapted for strict TypeScript.
+// ---------------------------------------------------------------------------
+
+const RC: bigint[] = [
+  0x0000000000000001n, 0x0000000000008082n, 0x800000000000808an,
+  0x8000000080008000n, 0x000000000000808bn, 0x0000000080000001n,
+  0x8000000080008081n, 0x8000000000008009n, 0x000000000000008an,
+  0x0000000000000088n, 0x0000000080008009n, 0x000000008000000an,
+  0x000000008000808bn, 0x800000000000008bn, 0x8000000000008089n,
+  0x8000000000008003n, 0x8000000000008002n, 0x8000000000000080n,
+  0x000000000000800an, 0x800000008000000an, 0x8000000080008081n,
+  0x8000000000008080n, 0x0000000080000001n, 0x8000000080008008n,
+];
+const ROTC: number[] = [
+  1, 3, 6, 10, 15, 21, 28, 36, 45, 55, 2, 14, 27, 41, 56, 8, 25, 43, 62, 18,
+  39, 61, 20, 44,
+];
+const PI: number[] = [
+  10, 7, 11, 17, 18, 3, 5, 16, 8, 21, 24, 4, 15, 23, 19, 13, 12, 2, 20, 14,
+  22, 9, 6, 1,
+];
+const M64 = 0xffffffffffffffffn;
+
+function keccakF(s: bigint[]): void {
+  for (let round = 0; round < 24; round++) {
+    const c0 = s[0]! ^ s[5]! ^ s[10]! ^ s[15]! ^ s[20]!;
+    const c1 = s[1]! ^ s[6]! ^ s[11]! ^ s[16]! ^ s[21]!;
+    const c2 = s[2]! ^ s[7]! ^ s[12]! ^ s[17]! ^ s[22]!;
+    const c3 = s[3]! ^ s[8]! ^ s[13]! ^ s[18]! ^ s[23]!;
+    const c4 = s[4]! ^ s[9]! ^ s[14]! ^ s[19]! ^ s[24]!;
+    const c = [c0, c1, c2, c3, c4];
+    for (let x = 0; x < 5; x++) {
+      const next = c[(x + 1) % 5]!;
+      const d = c[(x + 4) % 5]! ^ (((next << 1n) | (next >> 63n)) & M64);
+      for (let y = 0; y < 25; y += 5) s[y + x] = (s[y + x]! ^ d) & M64;
+    }
+    let last = s[1]!;
+    for (let i = 0; i < 24; i++) {
+      const j = PI[i]!;
+      const temp = s[j]!;
+      const r = BigInt(ROTC[i]!);
+      s[j] = ((last << r) | (last >> (64n - r))) & M64;
+      last = temp;
+    }
+    for (let y = 0; y < 25; y += 5) {
+      const t0 = s[y]!,
+        t1 = s[y + 1]!,
+        t2 = s[y + 2]!,
+        t3 = s[y + 3]!,
+        t4 = s[y + 4]!;
+      s[y] = (t0 ^ (~t1 & t2)) & M64;
+      s[y + 1] = (t1 ^ (~t2 & t3)) & M64;
+      s[y + 2] = (t2 ^ (~t3 & t4)) & M64;
+      s[y + 3] = (t3 ^ (~t4 & t0)) & M64;
+      s[y + 4] = (t4 ^ (~t0 & t1)) & M64;
+    }
+    s[0] = (s[0]! ^ RC[round]!) & M64;
+  }
+}
+
+function keccak256(data: Uint8Array): Uint8Array {
+  const rate = 136;
+  const s: bigint[] = new Array<bigint>(25).fill(0n);
+
+  let offset = 0;
+  while (offset + rate <= data.length) {
+    for (let i = 0; i < rate; i += 8) {
+      let lane = 0n;
+      for (let b = 0; b < 8; b++)
+        lane |= BigInt(data[offset + i + b]!) << BigInt(b * 8);
+      s[i >> 3] = s[i >> 3]! ^ lane;
+    }
+    keccakF(s);
+    offset += rate;
+  }
+
+  const padded = new Uint8Array(rate);
+  const remaining = data.length - offset;
+  for (let i = 0; i < remaining; i++) padded[i] = data[offset + i]!;
+  padded[remaining] = 0x01;
+  padded[rate - 1] = padded[rate - 1]! | 0x80;
+
+  for (let i = 0; i < rate; i += 8) {
+    let lane = 0n;
+    for (let b = 0; b < 8; b++) lane |= BigInt(padded[i + b]!) << BigInt(b * 8);
+    s[i >> 3] = s[i >> 3]! ^ lane;
+  }
+  keccakF(s);
+
+  const out = new Uint8Array(32);
+  for (let i = 0; i < 4; i++) {
+    const lane = s[i]!;
+    for (let b = 0; b < 8; b++)
+      out[i * 8 + b] = Number((lane >> BigInt(b * 8)) & 0xffn);
+  }
+  return out;
+}

--- a/src/execution/client.ts
+++ b/src/execution/client.ts
@@ -270,6 +270,9 @@ function validateDeposits(deposits: Deposit[]): void {
     if (!d.sparkTransferId || d.sparkTransferId.trim() === "") {
       throw new Error(`deposits[${i}].sparkTransferId is required`);
     }
+    if (typeof d.amount === "number" && (Number.isNaN(d.amount) || !Number.isFinite(d.amount))) {
+      throw new Error(`deposits[${i}].amount is not a valid number`);
+    }
     if (typeof d.amount === "bigint" ? d.amount <= 0n : d.amount <= 0) {
       throw new Error(`deposits[${i}].amount must be greater than zero`);
     }

--- a/src/execution/client.ts
+++ b/src/execution/client.ts
@@ -159,9 +159,7 @@ export class ExecutionClient {
     return this.accessToken;
   }
 
-  // ---------------------------------------------------------------------------
   // Private
-  // ---------------------------------------------------------------------------
 
   private async submitIntent(
     chainId: number,
@@ -261,9 +259,7 @@ export class ExecutionClient {
   }
 }
 
-// ---------------------------------------------------------------------------
 // Utilities
-// ---------------------------------------------------------------------------
 
 function validateDeposits(deposits: Deposit[]): void {
   if (deposits.length === 0) {

--- a/src/execution/client.ts
+++ b/src/execution/client.ts
@@ -186,6 +186,7 @@ export class ExecutionClient {
     };
 
     const messageJson = JSON.stringify(canonicalMessage);
+    console.warn("[ExecutionClient] canonical JSON:", messageJson);
     const signature = await this.signer.signMessage(messageJson);
 
     const body: Record<string, unknown> = {

--- a/src/execution/client.ts
+++ b/src/execution/client.ts
@@ -188,7 +188,6 @@ export class ExecutionClient {
     };
 
     const messageJson = JSON.stringify(canonicalMessage);
-    console.warn("[ExecutionClient] canonical JSON:", messageJson);
     const signature = await this.signer.signMessage(messageJson);
 
     const body: Record<string, unknown> = {

--- a/src/execution/client.ts
+++ b/src/execution/client.ts
@@ -168,7 +168,8 @@ export class ExecutionClient {
     const transfers: CanonicalTransferEntry[] = deposits.map((d) => {
       const entry: CanonicalTransferEntry = {
         transferId: d.sparkTransferId,
-        amountSats: Number(d.amount),
+        amountSats:
+          typeof d.amount === "bigint" ? Number(d.amount) : d.amount,
         assetType: d.asset.type === "btc" ? "NativeSats" : "BridgedToken",
       };
       if (d.asset.type === "token") {
@@ -192,7 +193,8 @@ export class ExecutionClient {
       deposits: deposits.map((d) => ({
         sparkTransferId: d.sparkTransferId,
         asset: d.asset,
-        amount: Number(d.amount),
+        amount:
+          typeof d.amount === "bigint" ? d.amount.toString() : d.amount,
       })),
       signature,
       nonce,
@@ -282,6 +284,9 @@ function hexToBytes(hex: string): Uint8Array {
     throw new Error(
       `hexToBytes: input has odd length (${clean.length} hex chars)`
     );
+  }
+  if (clean.length > 0 && !/^[0-9a-fA-F]+$/.test(clean)) {
+    throw new Error("hexToBytes: input contains invalid hex characters");
   }
   const bytes = new Uint8Array(clean.length / 2);
   for (let i = 0; i < bytes.length; i++) {

--- a/src/execution/client.ts
+++ b/src/execution/client.ts
@@ -119,7 +119,9 @@ export class ExecutionClient {
     params: ExecuteIntentParams & { signedTxHash?: string }
   ): Promise<ExecuteResponse> {
     this.requireAuth();
-    validateDeposits(params.deposits);
+    if (params.deposits.length > 0) {
+      validateDeposits(params.deposits);
+    }
 
     const txHash =
       params.signedTxHash ?? keccak256Hex(hexToBytes(params.signedTx));

--- a/src/execution/client.ts
+++ b/src/execution/client.ts
@@ -168,10 +168,16 @@ export class ExecutionClient {
     const nonce = crypto.randomUUID();
 
     const transfers: CanonicalTransferEntry[] = deposits.map((d) => {
+      const amount =
+        typeof d.amount === "bigint" ? Number(d.amount) : d.amount;
+      if (!Number.isSafeInteger(amount)) {
+        throw new Error(
+          `deposit amount ${d.amount} exceeds safe integer range (max ${Number.MAX_SAFE_INTEGER})`
+        );
+      }
       const entry: CanonicalTransferEntry = {
         transferId: d.sparkTransferId,
-        amountSats:
-          typeof d.amount === "bigint" ? Number(d.amount) : d.amount,
+        amountSats: amount,
         assetType: d.asset.type === "btc" ? "NativeSats" : "BridgedToken",
       };
       if (d.asset.type === "token") {

--- a/src/execution/client.ts
+++ b/src/execution/client.ts
@@ -102,7 +102,7 @@ export class ExecutionClient {
     };
 
     return this.submitIntent(params.chainId, params.deposits, action, {
-      recipient: params.recipient,
+      recipient: params.recipient.toLowerCase(),
     });
   }
 
@@ -168,7 +168,7 @@ export class ExecutionClient {
     const transfers: CanonicalTransferEntry[] = deposits.map((d) => {
       const entry: CanonicalTransferEntry = {
         transferId: d.sparkTransferId,
-        amountSats: d.amount,
+        amountSats: Number(d.amount),
         assetType: d.asset.type === "btc" ? "NativeSats" : "BridgedToken",
       };
       if (d.asset.type === "token") {
@@ -192,7 +192,7 @@ export class ExecutionClient {
       deposits: deposits.map((d) => ({
         sparkTransferId: d.sparkTransferId,
         asset: d.asset,
-        amount: d.amount,
+        amount: Number(d.amount),
       })),
       signature,
       nonce,
@@ -260,7 +260,7 @@ function validateDeposits(deposits: Deposit[]): void {
     if (!d.sparkTransferId || d.sparkTransferId.trim() === "") {
       throw new Error(`deposits[${i}].sparkTransferId is required`);
     }
-    if (d.amount <= 0) {
+    if (typeof d.amount === "bigint" ? d.amount <= 0n : d.amount <= 0) {
       throw new Error(`deposits[${i}].amount must be greater than zero`);
     }
     if (
@@ -278,6 +278,11 @@ function validateDeposits(deposits: Deposit[]): void {
 function hexToBytes(hex: string): Uint8Array {
   const clean =
     hex.startsWith("0x") || hex.startsWith("0X") ? hex.slice(2) : hex;
+  if (clean.length % 2 !== 0) {
+    throw new Error(
+      `hexToBytes: input has odd length (${clean.length} hex chars)`
+    );
+  }
   const bytes = new Uint8Array(clean.length / 2);
   for (let i = 0; i < bytes.length; i++) {
     bytes[i] = Number.parseInt(clean.substring(i * 2, i * 2 + 2), 16);

--- a/src/execution/conductor.ts
+++ b/src/execution/conductor.ts
@@ -92,9 +92,7 @@ export const Conductor = {
   },
 };
 
-// ---------------------------------------------------------------------------
 // High-level types
-// ---------------------------------------------------------------------------
 
 export interface ConductorConfig {
   conductorAddress: string;
@@ -143,9 +141,7 @@ export interface SwapBTCRequest {
   integrator?: string;
 }
 
-// ---------------------------------------------------------------------------
 // High-level swap functions
-// ---------------------------------------------------------------------------
 
 /** Execute an ERC20-to-ERC20 swap through the Conductor contract. */
 export async function swap(
@@ -219,9 +215,7 @@ export async function swapBTC(
   };
 }
 
-// ---------------------------------------------------------------------------
 // Approve + swap helpers
-// ---------------------------------------------------------------------------
 
 /** Submit an ERC20 approve transaction via an execute intent. */
 export async function approveToken(

--- a/src/execution/conductor.ts
+++ b/src/execution/conductor.ts
@@ -1,7 +1,7 @@
 /**
  * Conductor Contract SDK
  *
- * Low-level ABI encoding helpers plus high-level swap functions that handle
+ * ABI encoding via viem plus high-level swap functions that handle
  * calldata construction, EVM transaction building, intent wrapping, and
  * gateway submission — so the partner calls one function and gets a result.
  *
@@ -12,44 +12,34 @@
  *
  * @example High-level (SDK does everything):
  * ```typescript
- * import { ExecutionClient, swap } from "@flashnet/sdk/execution";
- *
- * const result = await swap(client, conductorConfig, {
- *   tokenIn: "0x...", tokenOut: "0x...", fee: 3000,
- *   amountIn: 1000000n, minAmountOut: 900000n,
- * }, deposits, intentSigner, evmSigner);
+ * const result = await swapWithApproval(client, conductorConfig, {
+ *   tokenIn, tokenOut, fee: 3000, amountIn: 1000000n, minAmountOut: 0n,
+ * }, [], evmSigner);
  * ```
  */
 
+import { encodeFunctionData } from "viem";
+import { conductorAbi } from "./abis/conductor";
+import { erc20Abi } from "./abis/erc20";
 import type { ExecutionClient } from "./client";
 import type { Deposit, ExecuteResponse } from "./types";
 import { fetchAllowance, fetchNonce } from "./evm";
 
 /** Parameters for Conductor.swap() — ERC20 to ERC20. */
 export interface SwapParams {
-  /** Input token address (0x-prefixed). */
   tokenIn: string;
-  /** Output token address (0x-prefixed). */
   tokenOut: string;
-  /** Uniswap V3 fee tier (500, 3000, or 10000). */
   fee: number;
-  /** Amount of tokenIn to swap (in wei/smallest unit). */
   amountIn: bigint;
-  /** Minimum acceptable output amount (slippage protection). */
   minAmountOut: bigint;
-  /** Integrator address (optional, defaults to zero address). Captured in event for future fees. */
   integrator?: string;
 }
 
 /** Parameters for Conductor.swapBTC() — native BTC to ERC20. */
 export interface SwapBTCParams {
-  /** Output token address (0x-prefixed). */
   tokenOut: string;
-  /** Uniswap V3 fee tier (500, 3000, or 10000). */
   fee: number;
-  /** Minimum acceptable output amount (slippage protection). */
   minAmountOut: bigint;
-  /** Integrator address (optional, defaults to zero address). */
   integrator?: string;
 }
 
@@ -58,181 +48,98 @@ const MAX_UINT256 = (1n << 256n) - 1n;
 const DEFAULT_SWAP_GAS_LIMIT = 1_000_000n;
 const DEFAULT_APPROVE_GAS_LIMIT = 100_000n;
 
-// Function selectors (keccak256 of canonical signature, first 4 bytes)
-// cast sig "swap(address,address,uint24,uint256,uint256,address)" → 0xfb408d07
-const SWAP_SELECTOR = "fb408d07";
-// cast sig "swapBTC(address,uint24,uint256,address)" → 0xad78c51c
-const SWAP_BTC_SELECTOR = "ad78c51c";
-// cast sig "approve(address,uint256)" → 0x095ea7b3
-const APPROVE_SELECTOR = "095ea7b3";
-
 /**
  * Conductor contract ABI encoding helpers.
- *
- * These functions produce calldata that can be used as the `signedTx.data` field
- * when building an EVM transaction targeting the Conductor contract address.
  */
 export const Conductor = {
-  /**
-   * Encode calldata for Conductor.swap().
-   *
-   * The caller must have approved the Conductor contract for `amountIn` of `tokenIn`
-   * before the transaction executes.
-   */
+  /** Encode calldata for Conductor.swap(). */
   encodeSwap(params: SwapParams): string {
-    const integrator = params.integrator ?? ZERO_ADDRESS;
-    return (
-      "0x" +
-      SWAP_SELECTOR +
-      abiEncodeAddress(params.tokenIn) +
-      abiEncodeAddress(params.tokenOut) +
-      abiEncodeUint(BigInt(params.fee), 256) +
-      abiEncodeUint(params.amountIn, 256) +
-      abiEncodeUint(params.minAmountOut, 256) +
-      abiEncodeAddress(integrator)
-    );
+    return encodeFunctionData({
+      abi: conductorAbi,
+      functionName: "swap",
+      args: [
+        params.tokenIn as `0x${string}`,
+        params.tokenOut as `0x${string}`,
+        params.fee,
+        params.amountIn,
+        params.minAmountOut,
+        (params.integrator ?? ZERO_ADDRESS) as `0x${string}`,
+      ],
+    });
   },
 
-  /**
-   * Encode calldata for Conductor.swapBTC().
-   *
-   * The caller sends native BTC as msg.value (set as the transaction's `value` field).
-   * The Conductor wraps it to WBTC and executes the swap.
-   */
+  /** Encode calldata for Conductor.swapBTC(). */
   encodeSwapBTC(params: SwapBTCParams): string {
-    const integrator = params.integrator ?? ZERO_ADDRESS;
-    return (
-      "0x" +
-      SWAP_BTC_SELECTOR +
-      abiEncodeAddress(params.tokenOut) +
-      abiEncodeUint(BigInt(params.fee), 256) +
-      abiEncodeUint(params.minAmountOut, 256) +
-      abiEncodeAddress(integrator)
-    );
+    return encodeFunctionData({
+      abi: conductorAbi,
+      functionName: "swapBTC",
+      args: [
+        params.tokenOut as `0x${string}`,
+        params.fee,
+        params.minAmountOut,
+        (params.integrator ?? ZERO_ADDRESS) as `0x${string}`,
+      ],
+    });
   },
 
-  /** The function selector for swap(address,address,uint24,uint256,uint256,address). */
-  SWAP_SELECTOR: `0x${SWAP_SELECTOR}` as const,
-
-  /** The function selector for swapBTC(address,uint24,uint256,address). */
-  SWAP_BTC_SELECTOR: `0x${SWAP_BTC_SELECTOR}` as const,
-
-  /**
-   * Encode calldata for ERC20 approve(spender, amount).
-   * Used internally by swapWithApproval but exposed for low-level usage.
-   */
+  /** Encode calldata for ERC20 approve(spender, amount). */
   encodeApprove(spender: string, amount: bigint): string {
-    return (
-      "0x" +
-      APPROVE_SELECTOR +
-      abiEncodeAddress(spender) +
-      abiEncodeUint(amount, 256)
-    );
+    return encodeFunctionData({
+      abi: erc20Abi,
+      functionName: "approve",
+      args: [spender as `0x${string}`, amount],
+    });
   },
 };
-
-// ---------------------------------------------------------------------------
-// ABI encoding helpers (minimal, no dependencies)
-// ---------------------------------------------------------------------------
-
-function abiEncodeAddress(addr: string): string {
-  const clean = addr.startsWith("0x") ? addr.slice(2) : addr;
-  return clean.toLowerCase().padStart(64, "0");
-}
-
-function abiEncodeUint(value: bigint, bits: number): string {
-  const max = (1n << BigInt(bits)) - 1n;
-  if (value < 0n || value > max) {
-    throw new Error(
-      `abiEncodeUint: value ${value} out of range for uint${bits}`
-    );
-  }
-  return value.toString(16).padStart(64, "0");
-}
 
 // ---------------------------------------------------------------------------
 // High-level types
 // ---------------------------------------------------------------------------
 
-/** Configuration for Conductor contract interactions. */
 export interface ConductorConfig {
-  /** Conductor proxy contract address (0x-prefixed). */
   conductorAddress: string;
-  /** WBTC address used by Conductor for native BTC wrapping. */
   wbtcAddress: string;
-  /** Uniswap V3 Factory address (for pool lookups). */
   factoryAddress: string;
-  /** JSON-RPC endpoint for EVM read queries. */
   rpcUrl: string;
-  /** Chain ID of the Flashnet EVM. */
   chainId: number;
 }
 
-/** Signer that can produce signed EVM transactions. */
 export interface EvmTransactionSigner {
-  /** Sign a raw EVM transaction and return the RLP-encoded signed tx as 0x-prefixed hex. */
   signTransaction(tx: UnsignedTransaction): Promise<string>;
-  /** Get the EVM address for this signer (0x-prefixed). */
   getAddress(): Promise<string>;
 }
 
-/** Unsigned EVM transaction fields. */
 export interface UnsignedTransaction {
-  /** Target contract address (0x-prefixed). */
   to: string;
-  /** Calldata (0x-prefixed hex). */
   data: string;
-  /** Native value in wei. */
   value: bigint;
-  /** Chain ID. */
   chainId: number;
-  /** Sender nonce (fetched automatically if omitted). */
   nonce?: number;
-  /** Gas limit (defaults to 500_000 if omitted). */
   gasLimit?: bigint;
-  /** Max fee per gas in wei (defaults to 0 for Flashnet's pinned base fee). */
   maxFeePerGas?: bigint;
-  /** Max priority fee per gas in wei (defaults to 0). */
   maxPriorityFeePerGas?: bigint;
 }
 
-/** Result of a high-level swap operation. */
 export interface SwapResult {
-  /** Unique handle for this submission attempt. */
   submissionId: string;
-  /** Canonical identifier of the logical intent content. */
   intentId: string;
-  /** Current status of the intent. */
   status: string;
 }
 
-/** Request for a high-level ERC20-to-ERC20 swap. */
 export interface SwapRequest {
-  /** Input token address (0x-prefixed). */
   tokenIn: string;
-  /** Output token address (0x-prefixed). */
   tokenOut: string;
-  /** Uniswap V3 fee tier (500, 3000, or 10000). */
   fee: number;
-  /** Amount of tokenIn to swap (in base units). */
   amountIn: bigint;
-  /** Minimum acceptable output amount (slippage protection). */
   minAmountOut: bigint;
-  /** Integrator address for future fee capture (optional). */
   integrator?: string;
 }
 
-/** Request for a high-level native-BTC-to-ERC20 swap. */
 export interface SwapBTCRequest {
-  /** Output token address (0x-prefixed). */
   tokenOut: string;
-  /** Uniswap V3 fee tier (500, 3000, or 10000). */
   fee: number;
-  /** Amount of native BTC to swap (in wei). */
   amountIn: bigint;
-  /** Minimum acceptable output amount (slippage protection). */
   minAmountOut: bigint;
-  /** Integrator address for future fee capture (optional). */
   integrator?: string;
 }
 
@@ -240,27 +147,7 @@ export interface SwapBTCRequest {
 // High-level swap functions
 // ---------------------------------------------------------------------------
 
-/**
- * Execute an ERC20-to-ERC20 swap through the Conductor contract.
- *
- * This is the batteries-included swap method. It:
- * 1. Encodes Conductor.swap() calldata
- * 2. Fetches the sender's nonce
- * 3. Builds and signs an EVM transaction via evmSigner
- * 4. Wraps it in a deposit-and-execute intent
- * 5. Submits to the execution gateway
- *
- * The caller provides deposits (Spark transfers funding the intent),
- * an intent signer (for canonical message signing), and an EVM signer
- * (for signing the raw EVM transaction).
- *
- * @param client - Authenticated ExecutionClient
- * @param config - Conductor and chain configuration
- * @param request - Swap parameters (tokenIn, tokenOut, fee, amounts)
- * @param deposits - Spark deposits funding this intent
- * @param evmSigner - Signs the raw EVM transaction
- * @returns Submission result from the execution gateway
- */
+/** Execute an ERC20-to-ERC20 swap through the Conductor contract. */
 export async function swap(
   client: ExecutionClient,
   config: ConductorConfig,
@@ -268,15 +155,7 @@ export async function swap(
   deposits: Deposit[],
   evmSigner: EvmTransactionSigner
 ): Promise<SwapResult> {
-  const calldata = Conductor.encodeSwap({
-    tokenIn: request.tokenIn,
-    tokenOut: request.tokenOut,
-    fee: request.fee,
-    amountIn: request.amountIn,
-    minAmountOut: request.minAmountOut,
-    integrator: request.integrator,
-  });
-
+  const calldata = Conductor.encodeSwap(request);
   const senderAddress = await evmSigner.getAddress();
   const nonce = await fetchNonce(config.rpcUrl, senderAddress);
 
@@ -304,19 +183,7 @@ export async function swap(
   };
 }
 
-/**
- * Execute a native-BTC-to-ERC20 swap through the Conductor contract.
- *
- * Same batteries-included approach as swap(), but sends native BTC
- * as msg.value (Conductor wraps it to WBTC internally).
- *
- * @param client - Authenticated ExecutionClient
- * @param config - Conductor and chain configuration
- * @param request - Swap parameters (tokenOut, fee, amountIn as native BTC, minAmountOut)
- * @param deposits - Spark deposits funding this intent
- * @param evmSigner - Signs the raw EVM transaction
- * @returns Submission result from the execution gateway
- */
+/** Execute a native-BTC-to-ERC20 swap through the Conductor contract. */
 export async function swapBTC(
   client: ExecutionClient,
   config: ConductorConfig,
@@ -324,13 +191,7 @@ export async function swapBTC(
   deposits: Deposit[],
   evmSigner: EvmTransactionSigner
 ): Promise<SwapResult> {
-  const calldata = Conductor.encodeSwapBTC({
-    tokenOut: request.tokenOut,
-    fee: request.fee,
-    minAmountOut: request.minAmountOut,
-    integrator: request.integrator,
-  });
-
+  const calldata = Conductor.encodeSwapBTC(request);
   const senderAddress = await evmSigner.getAddress();
   const nonce = await fetchNonce(config.rpcUrl, senderAddress);
 
@@ -362,12 +223,7 @@ export async function swapBTC(
 // Approve + swap helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Submit an ERC20 approve transaction via an execute intent.
- *
- * Grants `spender` an unlimited allowance for `token` from the signer's address.
- * Used internally by swapWithApproval but exposed for manual flows.
- */
+/** Submit an ERC20 approve transaction via an execute intent. */
 export async function approveToken(
   client: ExecutionClient,
   config: ConductorConfig,
@@ -406,10 +262,7 @@ export async function approveToken(
 
 /**
  * Execute an ERC20-to-ERC20 swap with automatic approval handling.
- *
- * Checks the current allowance for tokenIn on the Conductor. If insufficient,
- * submits an approve intent first, waits for it to land, then swaps.
- * This is the highest-level swap API — one call does everything.
+ * Checks allowance, approves if needed, then swaps.
  */
 export async function swapWithApproval(
   client: ExecutionClient,

--- a/src/execution/conductor.ts
+++ b/src/execution/conductor.ts
@@ -115,6 +115,12 @@ function abiEncodeAddress(addr: string): string {
   return clean.toLowerCase().padStart(64, "0");
 }
 
-function abiEncodeUint(value: bigint, _bits: number): string {
+function abiEncodeUint(value: bigint, bits: number): string {
+  const max = (1n << BigInt(bits)) - 1n;
+  if (value < 0n || value > max) {
+    throw new Error(
+      `abiEncodeUint: value ${value} out of range for uint${bits}`
+    );
+  }
   return value.toString(16).padStart(64, "0");
 }

--- a/src/execution/conductor.ts
+++ b/src/execution/conductor.ts
@@ -23,7 +23,7 @@
 
 import type { ExecutionClient } from "./client";
 import type { Deposit, ExecuteResponse } from "./types";
-import { fetchNonce } from "./evm";
+import { fetchAllowance, fetchNonce } from "./evm";
 
 /** Parameters for Conductor.swap() — ERC20 to ERC20. */
 export interface SwapParams {
@@ -54,12 +54,17 @@ export interface SwapBTCParams {
 }
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+const MAX_UINT256 = (1n << 256n) - 1n;
+const DEFAULT_SWAP_GAS_LIMIT = 1_000_000n;
+const DEFAULT_APPROVE_GAS_LIMIT = 100_000n;
 
 // Function selectors (keccak256 of canonical signature, first 4 bytes)
 // cast sig "swap(address,address,uint24,uint256,uint256,address)" → 0xfb408d07
 const SWAP_SELECTOR = "fb408d07";
 // cast sig "swapBTC(address,uint24,uint256,address)" → 0xad78c51c
 const SWAP_BTC_SELECTOR = "ad78c51c";
+// cast sig "approve(address,uint256)" → 0x095ea7b3
+const APPROVE_SELECTOR = "095ea7b3";
 
 /**
  * Conductor contract ABI encoding helpers.
@@ -111,6 +116,19 @@ export const Conductor = {
 
   /** The function selector for swapBTC(address,uint24,uint256,address). */
   SWAP_BTC_SELECTOR: `0x${SWAP_BTC_SELECTOR}` as const,
+
+  /**
+   * Encode calldata for ERC20 approve(spender, amount).
+   * Used internally by swapWithApproval but exposed for low-level usage.
+   */
+  encodeApprove(spender: string, amount: bigint): string {
+    return (
+      "0x" +
+      APPROVE_SELECTOR +
+      abiEncodeAddress(spender) +
+      abiEncodeUint(amount, 256)
+    );
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -268,7 +286,7 @@ export async function swap(
     value: 0n,
     chainId: config.chainId,
     nonce,
-    gasLimit: 500_000n,
+    gasLimit: DEFAULT_SWAP_GAS_LIMIT,
     maxFeePerGas: 0n,
     maxPriorityFeePerGas: 0n,
   });
@@ -322,7 +340,7 @@ export async function swapBTC(
     value: request.amountIn,
     chainId: config.chainId,
     nonce,
-    gasLimit: 500_000n,
+    gasLimit: DEFAULT_SWAP_GAS_LIMIT,
     maxFeePerGas: 0n,
     maxPriorityFeePerGas: 0n,
   });
@@ -338,4 +356,87 @@ export async function swapBTC(
     intentId: response.intentId,
     status: response.status,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Approve + swap helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Submit an ERC20 approve transaction via an execute intent.
+ *
+ * Grants `spender` an unlimited allowance for `token` from the signer's address.
+ * Used internally by swapWithApproval but exposed for manual flows.
+ */
+export async function approveToken(
+  client: ExecutionClient,
+  config: ConductorConfig,
+  token: string,
+  spender: string,
+  evmSigner: EvmTransactionSigner,
+  amount: bigint = MAX_UINT256
+): Promise<SwapResult> {
+  const calldata = Conductor.encodeApprove(spender, amount);
+  const senderAddress = await evmSigner.getAddress();
+  const nonce = await fetchNonce(config.rpcUrl, senderAddress);
+
+  const signedTx = await evmSigner.signTransaction({
+    to: token,
+    data: calldata,
+    value: 0n,
+    chainId: config.chainId,
+    nonce,
+    gasLimit: DEFAULT_APPROVE_GAS_LIMIT,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+  });
+
+  const response: ExecuteResponse = await client.submitExecute({
+    chainId: config.chainId,
+    deposits: [],
+    signedTx,
+  });
+
+  return {
+    submissionId: response.submissionId,
+    intentId: response.intentId,
+    status: response.status,
+  };
+}
+
+/**
+ * Execute an ERC20-to-ERC20 swap with automatic approval handling.
+ *
+ * Checks the current allowance for tokenIn on the Conductor. If insufficient,
+ * submits an approve intent first, waits for it to land, then swaps.
+ * This is the highest-level swap API — one call does everything.
+ */
+export async function swapWithApproval(
+  client: ExecutionClient,
+  config: ConductorConfig,
+  request: SwapRequest,
+  deposits: Deposit[],
+  evmSigner: EvmTransactionSigner,
+  approvalWaitMs: number = 3000
+): Promise<SwapResult> {
+  const senderAddress = await evmSigner.getAddress();
+  const allowance = await fetchAllowance(
+    config.rpcUrl,
+    request.tokenIn,
+    senderAddress,
+    config.conductorAddress
+  );
+
+  if (allowance < request.amountIn) {
+    await approveToken(
+      client,
+      config,
+      request.tokenIn,
+      config.conductorAddress,
+      evmSigner
+    );
+    await new Promise((resolve) => setTimeout(resolve, approvalWaitMs));
+  }
+
+  return swap(client, config, request, deposits, evmSigner);
 }

--- a/src/execution/conductor.ts
+++ b/src/execution/conductor.ts
@@ -1,22 +1,29 @@
 /**
- * Conductor Contract ABI Helpers
+ * Conductor Contract SDK
  *
- * Encodes calldata for the Conductor contract's swap functions.
- * Use with ExecutionClient.submitExecute() to build deposit-and-swap intents.
+ * Low-level ABI encoding helpers plus high-level swap functions that handle
+ * calldata construction, EVM transaction building, intent wrapping, and
+ * gateway submission — so the partner calls one function and gets a result.
  *
- * @example
+ * @example Low-level (calldata only):
  * ```typescript
- * import { ExecutionClient, Conductor } from "@flashnet/sdk/execution";
+ * const calldata = Conductor.encodeSwap({ tokenIn, tokenOut, fee, amountIn, minAmountOut });
+ * ```
  *
- * const calldata = Conductor.encodeSwap({
- *   tokenIn: "0x...",
- *   tokenOut: "0x...",
- *   fee: 3000,
- *   amountIn: 100000000000000000n,
- *   minAmountOut: 90000000000000000n,
- * });
+ * @example High-level (SDK does everything):
+ * ```typescript
+ * import { ExecutionClient, swap } from "@flashnet/sdk/execution";
+ *
+ * const result = await swap(client, conductorConfig, {
+ *   tokenIn: "0x...", tokenOut: "0x...", fee: 3000,
+ *   amountIn: 1000000n, minAmountOut: 900000n,
+ * }, deposits, intentSigner, evmSigner);
  * ```
  */
+
+import type { ExecutionClient } from "./client";
+import type { Deposit, ExecuteResponse } from "./types";
+import { fetchNonce } from "./evm";
 
 /** Parameters for Conductor.swap() — ERC20 to ERC20. */
 export interface SwapParams {
@@ -123,4 +130,212 @@ function abiEncodeUint(value: bigint, bits: number): string {
     );
   }
   return value.toString(16).padStart(64, "0");
+}
+
+// ---------------------------------------------------------------------------
+// High-level types
+// ---------------------------------------------------------------------------
+
+/** Configuration for Conductor contract interactions. */
+export interface ConductorConfig {
+  /** Conductor proxy contract address (0x-prefixed). */
+  conductorAddress: string;
+  /** WBTC address used by Conductor for native BTC wrapping. */
+  wbtcAddress: string;
+  /** Uniswap V3 Factory address (for pool lookups). */
+  factoryAddress: string;
+  /** JSON-RPC endpoint for EVM read queries. */
+  rpcUrl: string;
+  /** Chain ID of the Flashnet EVM. */
+  chainId: number;
+}
+
+/** Signer that can produce signed EVM transactions. */
+export interface EvmTransactionSigner {
+  /** Sign a raw EVM transaction and return the RLP-encoded signed tx as 0x-prefixed hex. */
+  signTransaction(tx: UnsignedTransaction): Promise<string>;
+  /** Get the EVM address for this signer (0x-prefixed). */
+  getAddress(): Promise<string>;
+}
+
+/** Unsigned EVM transaction fields. */
+export interface UnsignedTransaction {
+  /** Target contract address (0x-prefixed). */
+  to: string;
+  /** Calldata (0x-prefixed hex). */
+  data: string;
+  /** Native value in wei. */
+  value: bigint;
+  /** Chain ID. */
+  chainId: number;
+  /** Sender nonce (fetched automatically if omitted). */
+  nonce?: number;
+  /** Gas limit (defaults to 500_000 if omitted). */
+  gasLimit?: bigint;
+  /** Max fee per gas in wei (defaults to 0 for Flashnet's pinned base fee). */
+  maxFeePerGas?: bigint;
+  /** Max priority fee per gas in wei (defaults to 0). */
+  maxPriorityFeePerGas?: bigint;
+}
+
+/** Result of a high-level swap operation. */
+export interface SwapResult {
+  /** Unique handle for this submission attempt. */
+  submissionId: string;
+  /** Canonical identifier of the logical intent content. */
+  intentId: string;
+  /** Current status of the intent. */
+  status: string;
+}
+
+/** Request for a high-level ERC20-to-ERC20 swap. */
+export interface SwapRequest {
+  /** Input token address (0x-prefixed). */
+  tokenIn: string;
+  /** Output token address (0x-prefixed). */
+  tokenOut: string;
+  /** Uniswap V3 fee tier (500, 3000, or 10000). */
+  fee: number;
+  /** Amount of tokenIn to swap (in base units). */
+  amountIn: bigint;
+  /** Minimum acceptable output amount (slippage protection). */
+  minAmountOut: bigint;
+  /** Integrator address for future fee capture (optional). */
+  integrator?: string;
+}
+
+/** Request for a high-level native-BTC-to-ERC20 swap. */
+export interface SwapBTCRequest {
+  /** Output token address (0x-prefixed). */
+  tokenOut: string;
+  /** Uniswap V3 fee tier (500, 3000, or 10000). */
+  fee: number;
+  /** Amount of native BTC to swap (in wei). */
+  amountIn: bigint;
+  /** Minimum acceptable output amount (slippage protection). */
+  minAmountOut: bigint;
+  /** Integrator address for future fee capture (optional). */
+  integrator?: string;
+}
+
+// ---------------------------------------------------------------------------
+// High-level swap functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute an ERC20-to-ERC20 swap through the Conductor contract.
+ *
+ * This is the batteries-included swap method. It:
+ * 1. Encodes Conductor.swap() calldata
+ * 2. Fetches the sender's nonce
+ * 3. Builds and signs an EVM transaction via evmSigner
+ * 4. Wraps it in a deposit-and-execute intent
+ * 5. Submits to the execution gateway
+ *
+ * The caller provides deposits (Spark transfers funding the intent),
+ * an intent signer (for canonical message signing), and an EVM signer
+ * (for signing the raw EVM transaction).
+ *
+ * @param client - Authenticated ExecutionClient
+ * @param config - Conductor and chain configuration
+ * @param request - Swap parameters (tokenIn, tokenOut, fee, amounts)
+ * @param deposits - Spark deposits funding this intent
+ * @param evmSigner - Signs the raw EVM transaction
+ * @returns Submission result from the execution gateway
+ */
+export async function swap(
+  client: ExecutionClient,
+  config: ConductorConfig,
+  request: SwapRequest,
+  deposits: Deposit[],
+  evmSigner: EvmTransactionSigner
+): Promise<SwapResult> {
+  const calldata = Conductor.encodeSwap({
+    tokenIn: request.tokenIn,
+    tokenOut: request.tokenOut,
+    fee: request.fee,
+    amountIn: request.amountIn,
+    minAmountOut: request.minAmountOut,
+    integrator: request.integrator,
+  });
+
+  const senderAddress = await evmSigner.getAddress();
+  const nonce = await fetchNonce(config.rpcUrl, senderAddress);
+
+  const signedTx = await evmSigner.signTransaction({
+    to: config.conductorAddress,
+    data: calldata,
+    value: 0n,
+    chainId: config.chainId,
+    nonce,
+    gasLimit: 500_000n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+  });
+
+  const response: ExecuteResponse = await client.submitExecute({
+    chainId: config.chainId,
+    deposits,
+    signedTx,
+  });
+
+  return {
+    submissionId: response.submissionId,
+    intentId: response.intentId,
+    status: response.status,
+  };
+}
+
+/**
+ * Execute a native-BTC-to-ERC20 swap through the Conductor contract.
+ *
+ * Same batteries-included approach as swap(), but sends native BTC
+ * as msg.value (Conductor wraps it to WBTC internally).
+ *
+ * @param client - Authenticated ExecutionClient
+ * @param config - Conductor and chain configuration
+ * @param request - Swap parameters (tokenOut, fee, amountIn as native BTC, minAmountOut)
+ * @param deposits - Spark deposits funding this intent
+ * @param evmSigner - Signs the raw EVM transaction
+ * @returns Submission result from the execution gateway
+ */
+export async function swapBTC(
+  client: ExecutionClient,
+  config: ConductorConfig,
+  request: SwapBTCRequest,
+  deposits: Deposit[],
+  evmSigner: EvmTransactionSigner
+): Promise<SwapResult> {
+  const calldata = Conductor.encodeSwapBTC({
+    tokenOut: request.tokenOut,
+    fee: request.fee,
+    minAmountOut: request.minAmountOut,
+    integrator: request.integrator,
+  });
+
+  const senderAddress = await evmSigner.getAddress();
+  const nonce = await fetchNonce(config.rpcUrl, senderAddress);
+
+  const signedTx = await evmSigner.signTransaction({
+    to: config.conductorAddress,
+    data: calldata,
+    value: request.amountIn,
+    chainId: config.chainId,
+    nonce,
+    gasLimit: 500_000n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+  });
+
+  const response: ExecuteResponse = await client.submitExecute({
+    chainId: config.chainId,
+    deposits,
+    signedTx,
+  });
+
+  return {
+    submissionId: response.submissionId,
+    intentId: response.intentId,
+    status: response.status,
+  };
 }

--- a/src/execution/conductor.ts
+++ b/src/execution/conductor.ts
@@ -1,0 +1,120 @@
+/**
+ * Conductor Contract ABI Helpers
+ *
+ * Encodes calldata for the Conductor contract's swap functions.
+ * Use with ExecutionClient.submitExecute() to build deposit-and-swap intents.
+ *
+ * @example
+ * ```typescript
+ * import { ExecutionClient, Conductor } from "@flashnet/sdk/execution";
+ *
+ * const calldata = Conductor.encodeSwap({
+ *   tokenIn: "0x...",
+ *   tokenOut: "0x...",
+ *   fee: 3000,
+ *   amountIn: 100000000000000000n,
+ *   minAmountOut: 90000000000000000n,
+ * });
+ * ```
+ */
+
+/** Parameters for Conductor.swap() — ERC20 to ERC20. */
+export interface SwapParams {
+  /** Input token address (0x-prefixed). */
+  tokenIn: string;
+  /** Output token address (0x-prefixed). */
+  tokenOut: string;
+  /** Uniswap V3 fee tier (500, 3000, or 10000). */
+  fee: number;
+  /** Amount of tokenIn to swap (in wei/smallest unit). */
+  amountIn: bigint;
+  /** Minimum acceptable output amount (slippage protection). */
+  minAmountOut: bigint;
+  /** Integrator address (optional, defaults to zero address). Captured in event for future fees. */
+  integrator?: string;
+}
+
+/** Parameters for Conductor.swapBTC() — native BTC to ERC20. */
+export interface SwapBTCParams {
+  /** Output token address (0x-prefixed). */
+  tokenOut: string;
+  /** Uniswap V3 fee tier (500, 3000, or 10000). */
+  fee: number;
+  /** Minimum acceptable output amount (slippage protection). */
+  minAmountOut: bigint;
+  /** Integrator address (optional, defaults to zero address). */
+  integrator?: string;
+}
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+// Function selectors (keccak256 of canonical signature, first 4 bytes)
+// cast sig "swap(address,address,uint24,uint256,uint256,address)" → 0xfb408d07
+const SWAP_SELECTOR = "fb408d07";
+// cast sig "swapBTC(address,uint24,uint256,address)" → 0xad78c51c
+const SWAP_BTC_SELECTOR = "ad78c51c";
+
+/**
+ * Conductor contract ABI encoding helpers.
+ *
+ * These functions produce calldata that can be used as the `signedTx.data` field
+ * when building an EVM transaction targeting the Conductor contract address.
+ */
+export const Conductor = {
+  /**
+   * Encode calldata for Conductor.swap().
+   *
+   * The caller must have approved the Conductor contract for `amountIn` of `tokenIn`
+   * before the transaction executes.
+   */
+  encodeSwap(params: SwapParams): string {
+    const integrator = params.integrator ?? ZERO_ADDRESS;
+    return (
+      "0x" +
+      SWAP_SELECTOR +
+      abiEncodeAddress(params.tokenIn) +
+      abiEncodeAddress(params.tokenOut) +
+      abiEncodeUint(BigInt(params.fee), 256) +
+      abiEncodeUint(params.amountIn, 256) +
+      abiEncodeUint(params.minAmountOut, 256) +
+      abiEncodeAddress(integrator)
+    );
+  },
+
+  /**
+   * Encode calldata for Conductor.swapBTC().
+   *
+   * The caller sends native BTC as msg.value (set as the transaction's `value` field).
+   * The Conductor wraps it to WBTC and executes the swap.
+   */
+  encodeSwapBTC(params: SwapBTCParams): string {
+    const integrator = params.integrator ?? ZERO_ADDRESS;
+    return (
+      "0x" +
+      SWAP_BTC_SELECTOR +
+      abiEncodeAddress(params.tokenOut) +
+      abiEncodeUint(BigInt(params.fee), 256) +
+      abiEncodeUint(params.minAmountOut, 256) +
+      abiEncodeAddress(integrator)
+    );
+  },
+
+  /** The function selector for swap(address,address,uint24,uint256,uint256,address). */
+  SWAP_SELECTOR: `0x${SWAP_SELECTOR}` as const,
+
+  /** The function selector for swapBTC(address,uint24,uint256,address). */
+  SWAP_BTC_SELECTOR: `0x${SWAP_BTC_SELECTOR}` as const,
+};
+
+// ---------------------------------------------------------------------------
+// ABI encoding helpers (minimal, no dependencies)
+// ---------------------------------------------------------------------------
+
+function abiEncodeAddress(addr: string): string {
+  const clean = addr.startsWith("0x") ? addr.slice(2) : addr;
+  return clean.toLowerCase().padStart(64, "0");
+}
+
+function abiEncodeUint(value: bigint, _bits: number): string {
+  return value.toString(16).padStart(64, "0");
+}

--- a/src/execution/evm.ts
+++ b/src/execution/evm.ts
@@ -1,0 +1,252 @@
+/**
+ * EVM Read Helpers
+ *
+ * Zero-dependency EVM read utilities using raw JSON-RPC calls via fetch().
+ * Provides token metadata, balance, and allowance queries without requiring
+ * viem, ethers, or any other EVM library.
+ *
+ * @example
+ * ```typescript
+ * import { fetchTokenInfo, fetchTokenBalance } from "@flashnet/sdk/execution";
+ *
+ * const info = await fetchTokenInfo("http://localhost:8545", "0x...");
+ * const balance = await fetchTokenBalance("http://localhost:8545", "0x...", myAddress);
+ * ```
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** ERC-20 token metadata. */
+export interface TokenInfo {
+  /** Token contract address (0x-prefixed, checksummed or lowercase). */
+  address: string;
+  /** Token symbol (e.g. "USDB"). */
+  symbol: string;
+  /** Human-readable token name (e.g. "Bridged USD"). */
+  name: string;
+  /** Number of decimal places (e.g. 18). */
+  decimals: number;
+}
+
+// ---------------------------------------------------------------------------
+// ABI function selectors (4 bytes, 0x-prefixed)
+// ---------------------------------------------------------------------------
+
+/** keccak256("symbol()") */
+const SEL_SYMBOL = "0x95d89b41";
+/** keccak256("name()") */
+const SEL_NAME = "0x06fdde03";
+/** keccak256("decimals()") */
+const SEL_DECIMALS = "0x313ce567";
+/** keccak256("balanceOf(address)") */
+const SEL_BALANCE_OF = "0x70a08231";
+/** keccak256("allowance(address,address)") */
+const SEL_ALLOWANCE = "0xdd62ed3e";
+
+// ---------------------------------------------------------------------------
+// Raw JSON-RPC helper
+// ---------------------------------------------------------------------------
+
+let rpcIdCounter = 1;
+
+async function ethCall(
+  rpcUrl: string,
+  to: string,
+  data: string
+): Promise<string> {
+  const resp = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: rpcIdCounter++,
+      method: "eth_call",
+      params: [{ to, data }, "latest"],
+    }),
+  });
+
+  const json = (await resp.json()) as {
+    result?: string;
+    error?: { message: string };
+  };
+  if (json.error) {
+    throw new Error(`eth_call failed: ${json.error.message}`);
+  }
+  return json.result ?? "0x";
+}
+
+async function ethGetBalance(
+  rpcUrl: string,
+  address: string
+): Promise<string> {
+  const resp = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: rpcIdCounter++,
+      method: "eth_getBalance",
+      params: [address, "latest"],
+    }),
+  });
+
+  const json = (await resp.json()) as {
+    result?: string;
+    error?: { message: string };
+  };
+  if (json.error) {
+    throw new Error(`eth_getBalance failed: ${json.error.message}`);
+  }
+  return json.result ?? "0x0";
+}
+
+async function ethGetTransactionCount(
+  rpcUrl: string,
+  address: string
+): Promise<number> {
+  const resp = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: rpcIdCounter++,
+      method: "eth_getTransactionCount",
+      params: [address, "latest"],
+    }),
+  });
+
+  const json = (await resp.json()) as {
+    result?: string;
+    error?: { message: string };
+  };
+  if (json.error) {
+    throw new Error(`eth_getTransactionCount failed: ${json.error.message}`);
+  }
+  return Number(json.result ?? "0x0");
+}
+
+// ---------------------------------------------------------------------------
+// ABI decoding helpers
+// ---------------------------------------------------------------------------
+
+function padAddress(address: string): string {
+  const clean = address.startsWith("0x") ? address.slice(2) : address;
+  return clean.toLowerCase().padStart(64, "0");
+}
+
+function decodeString(hex: string): string {
+  // ABI-encoded string: offset (32 bytes) + length (32 bytes) + data
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  if (clean.length < 128) return "";
+  const length = Number("0x" + clean.substring(64, 128));
+  const data = clean.substring(128, 128 + length * 2);
+  let result = "";
+  for (let i = 0; i < data.length; i += 2) {
+    result += String.fromCharCode(Number.parseInt(data.substring(i, i + 2), 16));
+  }
+  return result;
+}
+
+function decodeUint(hex: string): bigint {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  if (clean.length === 0) return 0n;
+  return BigInt("0x" + clean.replace(/^0+/, "") || "0");
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch ERC-20 token metadata (symbol, name, decimals).
+ *
+ * @param rpcUrl - JSON-RPC endpoint URL
+ * @param tokenAddress - Token contract address (0x-prefixed)
+ * @returns Token metadata
+ */
+export async function fetchTokenInfo(
+  rpcUrl: string,
+  tokenAddress: string
+): Promise<TokenInfo> {
+  const [symbolHex, nameHex, decimalsHex] = await Promise.all([
+    ethCall(rpcUrl, tokenAddress, SEL_SYMBOL),
+    ethCall(rpcUrl, tokenAddress, SEL_NAME),
+    ethCall(rpcUrl, tokenAddress, SEL_DECIMALS),
+  ]);
+
+  return {
+    address: tokenAddress,
+    symbol: decodeString(symbolHex),
+    name: decodeString(nameHex),
+    decimals: Number(decodeUint(decimalsHex)),
+  };
+}
+
+/**
+ * Fetch ERC-20 token balance for an account.
+ *
+ * @param rpcUrl - JSON-RPC endpoint URL
+ * @param tokenAddress - Token contract address (0x-prefixed)
+ * @param account - Account address to query (0x-prefixed)
+ * @returns Balance in token base units
+ */
+export async function fetchTokenBalance(
+  rpcUrl: string,
+  tokenAddress: string,
+  account: string
+): Promise<bigint> {
+  const data = SEL_BALANCE_OF + padAddress(account);
+  const result = await ethCall(rpcUrl, tokenAddress, data);
+  return decodeUint(result);
+}
+
+/**
+ * Fetch native balance (BTC/ETH) for an account.
+ *
+ * @param rpcUrl - JSON-RPC endpoint URL
+ * @param account - Account address to query (0x-prefixed)
+ * @returns Balance in wei
+ */
+export async function fetchNativeBalance(
+  rpcUrl: string,
+  account: string
+): Promise<bigint> {
+  const result = await ethGetBalance(rpcUrl, account);
+  return BigInt(result);
+}
+
+/**
+ * Fetch ERC-20 allowance (how much `spender` can transfer from `owner`).
+ *
+ * @param rpcUrl - JSON-RPC endpoint URL
+ * @param tokenAddress - Token contract address (0x-prefixed)
+ * @param owner - Token owner address (0x-prefixed)
+ * @param spender - Approved spender address (0x-prefixed)
+ * @returns Allowance in token base units
+ */
+export async function fetchAllowance(
+  rpcUrl: string,
+  tokenAddress: string,
+  owner: string,
+  spender: string
+): Promise<bigint> {
+  const data = SEL_ALLOWANCE + padAddress(owner) + padAddress(spender);
+  const result = await ethCall(rpcUrl, tokenAddress, data);
+  return decodeUint(result);
+}
+
+/**
+ * Fetch the current nonce (transaction count) for an account.
+ *
+ * @param rpcUrl - JSON-RPC endpoint URL
+ * @param account - Account address to query (0x-prefixed)
+ * @returns Current nonce
+ */
+export async function fetchNonce(
+  rpcUrl: string,
+  account: string
+): Promise<number> {
+  return ethGetTransactionCount(rpcUrl, account);
+}

--- a/src/execution/evm.ts
+++ b/src/execution/evm.ts
@@ -1,9 +1,7 @@
 /**
  * EVM Read Helpers
  *
- * Zero-dependency EVM read utilities using raw JSON-RPC calls via fetch().
- * Provides token metadata, balance, and allowance queries without requiring
- * viem, ethers, or any other EVM library.
+ * Token metadata, balance, allowance, and nonce queries using viem.
  *
  * @example
  * ```typescript
@@ -13,6 +11,16 @@
  * const balance = await fetchTokenBalance("http://localhost:8545", "0x...", myAddress);
  * ```
  */
+
+import {
+  createPublicClient,
+  http,
+  type Address,
+  type PublicClient,
+  type Transport,
+  type Chain,
+} from "viem";
+import { erc20Abi } from "./abis/erc20";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -31,221 +39,18 @@ export interface TokenInfo {
 }
 
 // ---------------------------------------------------------------------------
-// ABI function selectors (4 bytes, 0x-prefixed)
+// Client cache
 // ---------------------------------------------------------------------------
 
-/** keccak256("symbol()") */
-const SEL_SYMBOL = "0x95d89b41";
-/** keccak256("name()") */
-const SEL_NAME = "0x06fdde03";
-/** keccak256("decimals()") */
-const SEL_DECIMALS = "0x313ce567";
+const clientCache = new Map<string, PublicClient<Transport, Chain | undefined>>();
 
-/** Multicall3 deterministic address (deployed on all chains via CREATE2). */
-const MULTICALL3 = "0xcA11bde05977b3631167028862bE2a173976CA11";
-/** keccak256("aggregate3((address,bool,bytes)[])") — first 4 bytes */
-const SEL_AGGREGATE3 = "0x82ad56cb";
-/** keccak256("balanceOf(address)") */
-const SEL_BALANCE_OF = "0x70a08231";
-/** keccak256("allowance(address,address)") */
-const SEL_ALLOWANCE = "0xdd62ed3e";
-
-// ---------------------------------------------------------------------------
-// Raw JSON-RPC helper
-// ---------------------------------------------------------------------------
-
-let rpcIdCounter = 1;
-
-async function ethCall(
-  rpcUrl: string,
-  to: string,
-  data: string
-): Promise<string> {
-  const resp = await fetch(rpcUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      id: rpcIdCounter++,
-      method: "eth_call",
-      params: [{ to, data }, "latest"],
-    }),
-  });
-
-  const json = (await resp.json()) as {
-    result?: string;
-    error?: { message: string };
-  };
-  if (json.error) {
-    throw new Error(`eth_call failed: ${json.error.message}`);
+function getClient(rpcUrl: string): PublicClient<Transport, Chain | undefined> {
+  let client = clientCache.get(rpcUrl);
+  if (!client) {
+    client = createPublicClient({ transport: http(rpcUrl) });
+    clientCache.set(rpcUrl, client);
   }
-  return json.result ?? "0x";
-}
-
-async function ethGetBalance(
-  rpcUrl: string,
-  address: string
-): Promise<string> {
-  const resp = await fetch(rpcUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      id: rpcIdCounter++,
-      method: "eth_getBalance",
-      params: [address, "latest"],
-    }),
-  });
-
-  const json = (await resp.json()) as {
-    result?: string;
-    error?: { message: string };
-  };
-  if (json.error) {
-    throw new Error(`eth_getBalance failed: ${json.error.message}`);
-  }
-  return json.result ?? "0x0";
-}
-
-async function ethGetTransactionCount(
-  rpcUrl: string,
-  address: string
-): Promise<number> {
-  const resp = await fetch(rpcUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      id: rpcIdCounter++,
-      method: "eth_getTransactionCount",
-      params: [address, "latest"],
-    }),
-  });
-
-  const json = (await resp.json()) as {
-    result?: string;
-    error?: { message: string };
-  };
-  if (json.error) {
-    throw new Error(`eth_getTransactionCount failed: ${json.error.message}`);
-  }
-  return Number(json.result ?? "0x0");
-}
-
-// ---------------------------------------------------------------------------
-// Multicall3 batching
-// ---------------------------------------------------------------------------
-
-/**
- * Batch multiple eth_call targets into a single RPC call via Multicall3.
- * Each call is { target, callData }. Returns raw hex results in order.
- * Falls back to parallel individual eth_calls if multicall3 reverts
- * (e.g. not deployed on the target chain).
- */
-async function multicall3(
-  rpcUrl: string,
-  calls: Array<{ target: string; callData: string }>
-): Promise<string[]> {
-  // Encode aggregate3 calldata:
-  // aggregate3((address target, bool allowFailure, bytes callData)[])
-  // Offset to dynamic array = 0x20
-  // Array length = calls.length
-  // Each element: target(address) + allowFailure(bool) + offset-to-callData
-  // Then the callData bytes for each element
-
-  // For simplicity with the zero-dep constraint, fall back to parallel calls
-  // when the encoding would be complex. The key optimization is 1 RPC round-trip.
-  const offsetToArray = "0".repeat(62) + "20"; // offset 32
-  const arrayLen = calls.length.toString(16).padStart(64, "0");
-
-  // Each tuple element has: address (32 bytes) + allowFailure (32 bytes) + offset to bytes (32 bytes)
-  // = 96 bytes per element header, then the bytes data
-  const headerSize = 96; // 3 words per element
-  let headParts = "";
-  let tailParts = "";
-  let tailOffset = calls.length * headerSize; // start of dynamic data, relative to array start
-
-  for (const call of calls) {
-    const cleanAddr = (call.target.startsWith("0x") ? call.target.slice(2) : call.target).toLowerCase();
-    headParts += cleanAddr.padStart(64, "0"); // target
-    headParts += "0".repeat(64); // allowFailure = false
-    headParts += tailOffset.toString(16).padStart(64, "0"); // offset to bytes
-
-    const cleanData = call.callData.startsWith("0x") ? call.callData.slice(2) : call.callData;
-    const dataLen = (cleanData.length / 2).toString(16).padStart(64, "0");
-    const paddedData = cleanData + "0".repeat((64 - (cleanData.length % 64)) % 64);
-    tailParts += dataLen + paddedData;
-    tailOffset += 32 + paddedData.length / 2; // length word + padded data bytes
-  }
-
-  const calldata = SEL_AGGREGATE3.slice(2) + offsetToArray + arrayLen + headParts + tailParts;
-
-  try {
-    const result = await ethCall(rpcUrl, MULTICALL3, "0x" + calldata);
-    return decodeMulticall3Results(result, calls.length);
-  } catch {
-    // Multicall3 not available — fall back to parallel individual calls
-    return Promise.all(
-      calls.map((c) => ethCall(rpcUrl, c.target, c.callData))
-    );
-  }
-}
-
-/** Decode aggregate3 return: (bool success, bytes returnData)[] */
-function decodeMulticall3Results(hex: string, count: number): string[] {
-  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
-  // First word: offset to array
-  // Second word: array length
-  // Then for each element: offset to tuple
-  // Each tuple: bool success (32 bytes) + offset to bytes (32 bytes) + bytes length + bytes data
-
-  const results: string[] = [];
-  const arrayOffset = Number("0x" + clean.substring(0, 64)) * 2;
-  const len = Number("0x" + clean.substring(arrayOffset, arrayOffset + 64));
-
-  for (let i = 0; i < Math.min(len, count); i++) {
-    const elemOffset = Number("0x" + clean.substring(arrayOffset + 64 + i * 64, arrayOffset + 128 + i * 64)) * 2;
-    const base = arrayOffset + 64 + elemOffset;
-    const success = Number("0x" + clean.substring(base, base + 64));
-    if (!success) {
-      results.push("0x");
-      continue;
-    }
-    const dataOffset = Number("0x" + clean.substring(base + 64, base + 128)) * 2;
-    const dataBase = base + dataOffset;
-    const dataLen = Number("0x" + clean.substring(dataBase, dataBase + 64));
-    results.push("0x" + clean.substring(dataBase + 64, dataBase + 64 + dataLen * 2));
-  }
-
-  return results;
-}
-
-// ---------------------------------------------------------------------------
-// ABI decoding helpers
-// ---------------------------------------------------------------------------
-
-function padAddress(address: string): string {
-  const clean = address.startsWith("0x") ? address.slice(2) : address;
-  return clean.toLowerCase().padStart(64, "0");
-}
-
-function decodeString(hex: string): string {
-  // ABI-encoded string: offset (32 bytes) + length (32 bytes) + data
-  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
-  if (clean.length < 128) return "";
-  const length = Number("0x" + clean.substring(64, 128));
-  const data = clean.substring(128, 128 + length * 2);
-  let result = "";
-  for (let i = 0; i < data.length; i += 2) {
-    result += String.fromCharCode(Number.parseInt(data.substring(i, i + 2), 16));
-  }
-  return result;
-}
-
-function decodeUint(hex: string): bigint {
-  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
-  if (clean.length === 0) return 0n;
-  return BigInt("0x" + (clean.replace(/^0+/, "") || "0"));
+  return client;
 }
 
 // ---------------------------------------------------------------------------
@@ -253,7 +58,7 @@ function decodeUint(hex: string): bigint {
 // ---------------------------------------------------------------------------
 
 /**
- * Fetch ERC-20 token metadata (symbol, name, decimals).
+ * Fetch ERC-20 token metadata (symbol, name, decimals) in a single multicall.
  *
  * @param rpcUrl - JSON-RPC endpoint URL
  * @param tokenAddress - Token contract address (0x-prefixed)
@@ -263,62 +68,55 @@ export async function fetchTokenInfo(
   rpcUrl: string,
   tokenAddress: string
 ): Promise<TokenInfo> {
-  // Batch symbol+name+decimals into a single RPC call via Multicall3.
-  const results = await multicall3(rpcUrl, [
-    { target: tokenAddress, callData: SEL_SYMBOL },
-    { target: tokenAddress, callData: SEL_NAME },
-    { target: tokenAddress, callData: SEL_DECIMALS },
-  ]);
+  const client = getClient(rpcUrl);
+  const addr = tokenAddress as Address;
+
+  const results = await client.multicall({
+    contracts: [
+      { address: addr, abi: erc20Abi, functionName: "symbol" },
+      { address: addr, abi: erc20Abi, functionName: "name" },
+      { address: addr, abi: erc20Abi, functionName: "decimals" },
+    ],
+  });
 
   return {
     address: tokenAddress,
-    symbol: decodeString(results[0] ?? "0x"),
-    name: decodeString(results[1] ?? "0x"),
-    decimals: Number(decodeUint(results[2] ?? "0x")),
+    symbol: results[0].status === "success" ? results[0].result : "",
+    name: results[1].status === "success" ? results[1].result : "",
+    decimals: results[2].status === "success" ? results[2].result : 0,
   };
 }
 
 /**
  * Fetch ERC-20 token balance for an account.
- *
- * @param rpcUrl - JSON-RPC endpoint URL
- * @param tokenAddress - Token contract address (0x-prefixed)
- * @param account - Account address to query (0x-prefixed)
- * @returns Balance in token base units
  */
 export async function fetchTokenBalance(
   rpcUrl: string,
   tokenAddress: string,
   account: string
 ): Promise<bigint> {
-  const data = SEL_BALANCE_OF + padAddress(account);
-  const result = await ethCall(rpcUrl, tokenAddress, data);
-  return decodeUint(result);
+  const client = getClient(rpcUrl);
+  return client.readContract({
+    address: tokenAddress as Address,
+    abi: erc20Abi,
+    functionName: "balanceOf",
+    args: [account as Address],
+  });
 }
 
 /**
  * Fetch native balance (BTC/ETH) for an account.
- *
- * @param rpcUrl - JSON-RPC endpoint URL
- * @param account - Account address to query (0x-prefixed)
- * @returns Balance in wei
  */
 export async function fetchNativeBalance(
   rpcUrl: string,
   account: string
 ): Promise<bigint> {
-  const result = await ethGetBalance(rpcUrl, account);
-  return BigInt(result);
+  const client = getClient(rpcUrl);
+  return client.getBalance({ address: account as Address });
 }
 
 /**
  * Fetch ERC-20 allowance (how much `spender` can transfer from `owner`).
- *
- * @param rpcUrl - JSON-RPC endpoint URL
- * @param tokenAddress - Token contract address (0x-prefixed)
- * @param owner - Token owner address (0x-prefixed)
- * @param spender - Approved spender address (0x-prefixed)
- * @returns Allowance in token base units
  */
 export async function fetchAllowance(
   rpcUrl: string,
@@ -326,21 +124,22 @@ export async function fetchAllowance(
   owner: string,
   spender: string
 ): Promise<bigint> {
-  const data = SEL_ALLOWANCE + padAddress(owner) + padAddress(spender);
-  const result = await ethCall(rpcUrl, tokenAddress, data);
-  return decodeUint(result);
+  const client = getClient(rpcUrl);
+  return client.readContract({
+    address: tokenAddress as Address,
+    abi: erc20Abi,
+    functionName: "allowance",
+    args: [owner as Address, spender as Address],
+  });
 }
 
 /**
  * Fetch the current nonce (transaction count) for an account.
- *
- * @param rpcUrl - JSON-RPC endpoint URL
- * @param account - Account address to query (0x-prefixed)
- * @returns Current nonce
  */
 export async function fetchNonce(
   rpcUrl: string,
   account: string
 ): Promise<number> {
-  return ethGetTransactionCount(rpcUrl, account);
+  const client = getClient(rpcUrl);
+  return client.getTransactionCount({ address: account as Address });
 }

--- a/src/execution/evm.ts
+++ b/src/execution/evm.ts
@@ -40,6 +40,11 @@ const SEL_SYMBOL = "0x95d89b41";
 const SEL_NAME = "0x06fdde03";
 /** keccak256("decimals()") */
 const SEL_DECIMALS = "0x313ce567";
+
+/** Multicall3 deterministic address (deployed on all chains via CREATE2). */
+const MULTICALL3 = "0xcA11bde05977b3631167028862bE2a173976CA11";
+/** keccak256("aggregate3((address,bool,bytes)[])") — first 4 bytes */
+const SEL_AGGREGATE3 = "0x82ad56cb";
 /** keccak256("balanceOf(address)") */
 const SEL_BALANCE_OF = "0x70a08231";
 /** keccak256("allowance(address,address)") */
@@ -128,6 +133,94 @@ async function ethGetTransactionCount(
 }
 
 // ---------------------------------------------------------------------------
+// Multicall3 batching
+// ---------------------------------------------------------------------------
+
+/**
+ * Batch multiple eth_call targets into a single RPC call via Multicall3.
+ * Each call is { target, callData }. Returns raw hex results in order.
+ * Falls back to parallel individual eth_calls if multicall3 reverts
+ * (e.g. not deployed on the target chain).
+ */
+async function multicall3(
+  rpcUrl: string,
+  calls: Array<{ target: string; callData: string }>
+): Promise<string[]> {
+  // Encode aggregate3 calldata:
+  // aggregate3((address target, bool allowFailure, bytes callData)[])
+  // Offset to dynamic array = 0x20
+  // Array length = calls.length
+  // Each element: target(address) + allowFailure(bool) + offset-to-callData
+  // Then the callData bytes for each element
+
+  // For simplicity with the zero-dep constraint, fall back to parallel calls
+  // when the encoding would be complex. The key optimization is 1 RPC round-trip.
+  const offsetToArray = "0".repeat(62) + "20"; // offset 32
+  const arrayLen = calls.length.toString(16).padStart(64, "0");
+
+  // Each tuple element has: address (32 bytes) + allowFailure (32 bytes) + offset to bytes (32 bytes)
+  // = 96 bytes per element header, then the bytes data
+  const headerSize = 96; // 3 words per element
+  let headParts = "";
+  let tailParts = "";
+  let tailOffset = calls.length * headerSize; // start of dynamic data, relative to array start
+
+  for (const call of calls) {
+    const cleanAddr = (call.target.startsWith("0x") ? call.target.slice(2) : call.target).toLowerCase();
+    headParts += cleanAddr.padStart(64, "0"); // target
+    headParts += "0".repeat(64); // allowFailure = false
+    headParts += tailOffset.toString(16).padStart(64, "0"); // offset to bytes
+
+    const cleanData = call.callData.startsWith("0x") ? call.callData.slice(2) : call.callData;
+    const dataLen = (cleanData.length / 2).toString(16).padStart(64, "0");
+    const paddedData = cleanData + "0".repeat((64 - (cleanData.length % 64)) % 64);
+    tailParts += dataLen + paddedData;
+    tailOffset += 32 + paddedData.length / 2; // length word + padded data bytes
+  }
+
+  const calldata = SEL_AGGREGATE3.slice(2) + offsetToArray + arrayLen + headParts + tailParts;
+
+  try {
+    const result = await ethCall(rpcUrl, MULTICALL3, "0x" + calldata);
+    return decodeMulticall3Results(result, calls.length);
+  } catch {
+    // Multicall3 not available — fall back to parallel individual calls
+    return Promise.all(
+      calls.map((c) => ethCall(rpcUrl, c.target, c.callData))
+    );
+  }
+}
+
+/** Decode aggregate3 return: (bool success, bytes returnData)[] */
+function decodeMulticall3Results(hex: string, count: number): string[] {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  // First word: offset to array
+  // Second word: array length
+  // Then for each element: offset to tuple
+  // Each tuple: bool success (32 bytes) + offset to bytes (32 bytes) + bytes length + bytes data
+
+  const results: string[] = [];
+  const arrayOffset = Number("0x" + clean.substring(0, 64)) * 2;
+  const len = Number("0x" + clean.substring(arrayOffset, arrayOffset + 64));
+
+  for (let i = 0; i < Math.min(len, count); i++) {
+    const elemOffset = Number("0x" + clean.substring(arrayOffset + 64 + i * 64, arrayOffset + 128 + i * 64)) * 2;
+    const base = arrayOffset + 64 + elemOffset;
+    const success = Number("0x" + clean.substring(base, base + 64));
+    if (!success) {
+      results.push("0x");
+      continue;
+    }
+    const dataOffset = Number("0x" + clean.substring(base + 64, base + 128)) * 2;
+    const dataBase = base + dataOffset;
+    const dataLen = Number("0x" + clean.substring(dataBase, dataBase + 64));
+    results.push("0x" + clean.substring(dataBase + 64, dataBase + 64 + dataLen * 2));
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
 // ABI decoding helpers
 // ---------------------------------------------------------------------------
 
@@ -170,17 +263,18 @@ export async function fetchTokenInfo(
   rpcUrl: string,
   tokenAddress: string
 ): Promise<TokenInfo> {
-  const [symbolHex, nameHex, decimalsHex] = await Promise.all([
-    ethCall(rpcUrl, tokenAddress, SEL_SYMBOL),
-    ethCall(rpcUrl, tokenAddress, SEL_NAME),
-    ethCall(rpcUrl, tokenAddress, SEL_DECIMALS),
+  // Batch symbol+name+decimals into a single RPC call via Multicall3.
+  const results = await multicall3(rpcUrl, [
+    { target: tokenAddress, callData: SEL_SYMBOL },
+    { target: tokenAddress, callData: SEL_NAME },
+    { target: tokenAddress, callData: SEL_DECIMALS },
   ]);
 
   return {
     address: tokenAddress,
-    symbol: decodeString(symbolHex),
-    name: decodeString(nameHex),
-    decimals: Number(decodeUint(decimalsHex)),
+    symbol: decodeString(results[0] ?? "0x"),
+    name: decodeString(results[1] ?? "0x"),
+    decimals: Number(decodeUint(results[2] ?? "0x")),
   };
 }
 

--- a/src/execution/evm.ts
+++ b/src/execution/evm.ts
@@ -22,9 +22,7 @@ import {
 } from "viem";
 import { erc20Abi } from "./abis/erc20";
 
-// ---------------------------------------------------------------------------
 // Types
-// ---------------------------------------------------------------------------
 
 /** ERC-20 token metadata. */
 export interface TokenInfo {
@@ -38,9 +36,7 @@ export interface TokenInfo {
   decimals: number;
 }
 
-// ---------------------------------------------------------------------------
 // Client cache
-// ---------------------------------------------------------------------------
 
 const clientCache = new Map<string, PublicClient<Transport, Chain | undefined>>();
 
@@ -53,9 +49,7 @@ function getClient(rpcUrl: string): PublicClient<Transport, Chain | undefined> {
   return client;
 }
 
-// ---------------------------------------------------------------------------
 // Public API
-// ---------------------------------------------------------------------------
 
 /**
  * Fetch ERC-20 token metadata (symbol, name, decimals) in a single multicall.

--- a/src/execution/evm.ts
+++ b/src/execution/evm.ts
@@ -12,15 +12,9 @@
  * ```
  */
 
-import {
-  createPublicClient,
-  http,
-  type Address,
-  type PublicClient,
-  type Transport,
-  type Chain,
-} from "viem";
+import { type Address } from "viem";
 import { erc20Abi } from "./abis/erc20";
+import { getClient } from "./rpc";
 
 // Types
 
@@ -34,19 +28,6 @@ export interface TokenInfo {
   name: string;
   /** Number of decimal places (e.g. 18). */
   decimals: number;
-}
-
-// Client cache
-
-const clientCache = new Map<string, PublicClient<Transport, Chain | undefined>>();
-
-function getClient(rpcUrl: string): PublicClient<Transport, Chain | undefined> {
-  let client = clientCache.get(rpcUrl);
-  if (!client) {
-    client = createPublicClient({ transport: http(rpcUrl) });
-    clientCache.set(rpcUrl, client);
-  }
-  return client;
 }
 
 // Public API

--- a/src/execution/evm.ts
+++ b/src/execution/evm.ts
@@ -152,7 +152,7 @@ function decodeString(hex: string): string {
 function decodeUint(hex: string): bigint {
   const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
   if (clean.length === 0) return 0n;
-  return BigInt("0x" + clean.replace(/^0+/, "") || "0");
+  return BigInt("0x" + (clean.replace(/^0+/, "") || "0"));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Flashnet Execution Layer Module
+ *
+ * New execution-layer client for interacting with the Flashnet execution gateway.
+ * This module is separate from the legacy AMM client (FlashnetClient) which talks
+ * to flashnet-services/settlement.
+ *
+ * @example
+ * ```typescript
+ * import { ExecutionClient } from "@flashnet/sdk/execution";
+ * ```
+ */
+
+export { ExecutionClient } from "./client";
+export type {
+  CanonicalIntentAction,
+  CanonicalIntentMessage,
+  CanonicalTransferEntry,
+  Deposit,
+  DepositAsset,
+  DepositIntentParams,
+  ExecuteIntentParams,
+  ExecuteResponse,
+  ExecutionClientConfig,
+  ExecutionSigner,
+} from "./types";

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -12,6 +12,7 @@
  */
 
 export { ExecutionClient } from "./client";
+export { Conductor, type SwapParams, type SwapBTCParams } from "./conductor";
 export type {
   CanonicalIntentAction,
   CanonicalIntentMessage,

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -1,18 +1,85 @@
 /**
  * Flashnet Execution Layer Module
  *
- * New execution-layer client for interacting with the Flashnet execution gateway.
- * This module is separate from the legacy AMM client (FlashnetClient) which talks
- * to flashnet-services/settlement.
+ * Complete SDK for interacting with the Flashnet execution gateway,
+ * Conductor contract (AMM aggregator), and on-chain EVM state.
  *
- * @example
+ * @example High-level swap (SDK does everything):
  * ```typescript
- * import { ExecutionClient } from "@flashnet/sdk/execution";
+ * import { ExecutionClient, swap } from "@flashnet/sdk/execution";
+ *
+ * const client = new ExecutionClient({ gatewayUrl }, signer);
+ * await client.authenticate();
+ *
+ * const result = await swap(client, conductorConfig, {
+ *   tokenIn: USDB, tokenOut: WBTC, fee: 3000,
+ *   amountIn: 1000000n, minAmountOut: 900000n,
+ * }, deposits, evmSigner);
+ * ```
+ *
+ * @example Low-level (calldata encoding only):
+ * ```typescript
+ * import { Conductor, fetchTokenBalance } from "@flashnet/sdk/execution";
+ *
+ * const calldata = Conductor.encodeSwap({ tokenIn, tokenOut, fee, amountIn, minAmountOut });
+ * const balance = await fetchTokenBalance(rpcUrl, tokenAddress, myAddress);
  * ```
  */
 
+// Core client
 export { ExecutionClient } from "./client";
-export { Conductor, type SwapParams, type SwapBTCParams } from "./conductor";
+
+// Conductor: low-level encoding + high-level swap functions
+export {
+  Conductor,
+  swap,
+  swapBTC,
+  type SwapParams,
+  type SwapBTCParams,
+  type ConductorConfig,
+  type EvmTransactionSigner,
+  type UnsignedTransaction,
+  type SwapResult,
+  type SwapRequest,
+  type SwapBTCRequest,
+} from "./conductor";
+
+// EVM read helpers
+export {
+  fetchTokenInfo,
+  fetchTokenBalance,
+  fetchNativeBalance,
+  fetchAllowance,
+  fetchNonce,
+  type TokenInfo,
+} from "./evm";
+
+// Pool queries
+export {
+  getPoolAddress,
+  fetchPoolInfo,
+  sortTokens,
+  type PoolInfo,
+} from "./pool";
+
+// Pool creation encoding
+export {
+  encodeCreateBTCPool,
+  encodeCreatePoolParams,
+  type CreateBTCPoolParams,
+  type CreatePoolParams,
+  type PermitSignature,
+} from "./pool-creation";
+
+// Price math
+export {
+  priceToSqrtPriceX96,
+  sqrtPriceX96ToPrice,
+  fullRangeTicks,
+  FEE_TIERS,
+} from "./price-math";
+
+// Types
 export type {
   CanonicalIntentAction,
   CanonicalIntentMessage,

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -73,6 +73,18 @@ export {
   type PermitSignature,
 } from "./pool-creation";
 
+// Spark Bridge: withdrawals + token resolution
+export {
+  encodeWithdrawSats,
+  encodeWithdrawToken,
+  queryBridgedTokenAddress,
+  waitForBridgedTokenAddress,
+  withdrawSats,
+  withdrawToken,
+  type BridgeConfig,
+  type WithdrawResult,
+} from "./bridge";
+
 // Price math
 export {
   priceToSqrtPriceX96,

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -34,6 +34,8 @@ export {
   Conductor,
   swap,
   swapBTC,
+  approveToken,
+  swapWithApproval,
   type SwapParams,
   type SwapBTCParams,
   type ConductorConfig,

--- a/src/execution/pool-creation.ts
+++ b/src/execution/pool-creation.ts
@@ -1,0 +1,236 @@
+/**
+ * Conductor Pool Creation Helpers
+ *
+ * ABI encoding for Conductor.createPool() and Conductor.createBTCPool().
+ * These build the calldata that goes into a deposit-and-execute intent.
+ *
+ * @example
+ * ```typescript
+ * import { encodeCreateBTCPool } from "@flashnet/sdk/execution";
+ *
+ * const calldata = encodeCreateBTCPool({
+ *   wbtcAddress: "0x...",
+ *   otherTokenAddress: "0x...",
+ *   fee: 3000,
+ *   tickSpacing: 60,
+ *   sqrtPriceX96: 79228162514264337593543950336n,
+ *   wbtcAmount: 1000000000000000000n,
+ *   otherAmount: 1000000000000000000n,
+ *   hostId: "0x...",
+ *   feeRecipient: "0x...",
+ *   permit: { value: 1000n, deadline: 9999999999n, v: 27, r: "0x...", s: "0x..." },
+ * });
+ * ```
+ */
+
+import { sortTokens } from "./pool";
+import { fullRangeTicks } from "./price-math";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** EIP-2612 permit signature data for Conductor pool creation. */
+export interface PermitSignature {
+  value: bigint;
+  deadline: bigint;
+  v: number;
+  r: string;
+  s: string;
+}
+
+/** Parameters for creating a BTC + ERC-20 pool via Conductor. */
+export interface CreateBTCPoolParams {
+  /** WBTC contract address. */
+  wbtcAddress: string;
+  /** The other token address. */
+  otherTokenAddress: string;
+  /** Fee tier (e.g. 500, 3000, 10000). */
+  fee: number;
+  /** Tick spacing for the fee tier. */
+  tickSpacing: number;
+  /** Initial sqrtPriceX96 for the pool. */
+  sqrtPriceX96: bigint;
+  /** Amount of WBTC to provide (in wei). */
+  wbtcAmount: bigint;
+  /** Amount of the other token to provide (in base units). */
+  otherAmount: bigint;
+  /** Host identifier (32-byte hex). */
+  hostId: string;
+  /** Address to receive host fees. */
+  feeRecipient: string;
+  /** EIP-2612 permit for the non-BTC token. */
+  permit: PermitSignature;
+}
+
+/** Parameters for creating an ERC-20 only pool via Conductor (Permit2). */
+export interface CreatePoolParams {
+  /** First token address. */
+  tokenA: string;
+  /** Second token address. */
+  tokenB: string;
+  /** Fee tier. */
+  fee: number;
+  /** Tick spacing for the fee tier. */
+  tickSpacing: number;
+  /** Initial sqrtPriceX96. */
+  sqrtPriceX96: bigint;
+  /** Amount of tokenA (in base units). */
+  amountA: bigint;
+  /** Amount of tokenB (in base units). */
+  amountB: bigint;
+  /** Host identifier (32-byte hex). */
+  hostId: string;
+  /** Address to receive host fees. */
+  feeRecipient: string;
+}
+
+// ---------------------------------------------------------------------------
+// ABI encoding helpers
+// ---------------------------------------------------------------------------
+
+function abiEncodeAddress(address: string): string {
+  const clean = address.startsWith("0x") ? address.slice(2) : address;
+  return clean.toLowerCase().padStart(64, "0");
+}
+
+function abiEncodeUint256(value: bigint): string {
+  if (value < 0n) throw new Error("abiEncodeUint256: value must be non-negative");
+  if (value >= 1n << 256n)
+    throw new Error("abiEncodeUint256: value exceeds uint256 max");
+  return value.toString(16).padStart(64, "0");
+}
+
+function abiEncodeUint160(value: bigint): string {
+  if (value >= 1n << 160n)
+    throw new Error("abiEncodeUint160: value exceeds uint160 max");
+  return value.toString(16).padStart(64, "0");
+}
+
+function abiEncodeUint24(value: number): string {
+  if (value < 0 || value >= 2 ** 24)
+    throw new Error("abiEncodeUint24: value out of range");
+  return value.toString(16).padStart(64, "0");
+}
+
+function abiEncodeInt24(value: number): string {
+  if (value < -(2 ** 23) || value >= 2 ** 23)
+    throw new Error("abiEncodeInt24: value out of range");
+  if (value >= 0) {
+    return value.toString(16).padStart(64, "0");
+  }
+  // Two's complement for negative values
+  const twos = BigInt(value) + (1n << 256n);
+  return twos.toString(16).padStart(64, "0");
+}
+
+function abiEncodeUint8(value: number): string {
+  return value.toString(16).padStart(64, "0");
+}
+
+function abiEncodeBytes32(hex: string): string {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  return clean.padEnd(64, "0");
+}
+
+// ---------------------------------------------------------------------------
+// Function selectors
+// ---------------------------------------------------------------------------
+
+/**
+ * createBTCPool((address,address,uint24,uint160,int24,int24,uint256,uint256,uint256,uint256,bytes32,address),(uint256,uint256,uint8,bytes32,bytes32))
+ */
+const SEL_CREATE_BTC_POOL = "0xb1e2eda2";
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Encode calldata for Conductor.createBTCPool().
+ * Handles token sorting, full-range tick calculation, and permit struct encoding.
+ *
+ * @returns Object with calldata (0x-prefixed hex) and wbtcAmountWei for the tx value field
+ */
+export function encodeCreateBTCPool(params: CreateBTCPoolParams): {
+  calldata: string;
+  wbtcAmountWei: bigint;
+} {
+  const [token0, token1] = sortTokens(
+    params.wbtcAddress,
+    params.otherTokenAddress
+  );
+  const wbtcIsToken0 =
+    token0.toLowerCase() === params.wbtcAddress.toLowerCase();
+
+  const amount0Desired = wbtcIsToken0 ? params.wbtcAmount : params.otherAmount;
+  const amount1Desired = wbtcIsToken0 ? params.otherAmount : params.wbtcAmount;
+
+  const { tickLower, tickUpper } = fullRangeTicks(params.tickSpacing);
+
+  // Encode the CreatePoolParams tuple (12 fields)
+  const poolParams =
+    abiEncodeAddress(token0) +
+    abiEncodeAddress(token1) +
+    abiEncodeUint24(params.fee) +
+    abiEncodeUint160(params.sqrtPriceX96) +
+    abiEncodeInt24(tickLower) +
+    abiEncodeInt24(tickUpper) +
+    abiEncodeUint256(amount0Desired) +
+    abiEncodeUint256(amount1Desired) +
+    abiEncodeUint256(0n) + // amount0Min
+    abiEncodeUint256(0n) + // amount1Min
+    abiEncodeBytes32(params.hostId) +
+    abiEncodeAddress(params.feeRecipient);
+
+  // Encode the ERC20PermitSig tuple (5 fields)
+  const permitData =
+    abiEncodeUint256(params.permit.value) +
+    abiEncodeUint256(params.permit.deadline) +
+    abiEncodeUint8(params.permit.v) +
+    abiEncodeBytes32(params.permit.r) +
+    abiEncodeBytes32(params.permit.s);
+
+  // ABI encoding with tuple offsets
+  const paramsOffset = abiEncodeUint256(64n); // offset to first tuple (2 * 32 bytes)
+  const permitOffset = abiEncodeUint256(BigInt(64 + poolParams.length / 2)); // offset to second tuple
+
+  const calldata =
+    SEL_CREATE_BTC_POOL + paramsOffset + permitOffset + poolParams + permitData;
+
+  return { calldata: "0x" + calldata.replace(/^0x/, ""), wbtcAmountWei: params.wbtcAmount };
+}
+
+/**
+ * Encode calldata for Conductor.createPool() (ERC20-only pools via Permit2).
+ *
+ * Note: This function encodes the pool parameters only. The Permit2 batch
+ * signature must be constructed separately based on the partner's signing flow.
+ *
+ * @returns Encoded pool parameters (not full calldata — Permit2 sig appended by caller)
+ */
+export function encodeCreatePoolParams(params: CreatePoolParams): {
+  token0: string;
+  token1: string;
+  amount0Desired: bigint;
+  amount1Desired: bigint;
+  tickLower: number;
+  tickUpper: number;
+} {
+  const [token0, token1] = sortTokens(params.tokenA, params.tokenB);
+  const aIsToken0 = token0.toLowerCase() === params.tokenA.toLowerCase();
+
+  const amount0Desired = aIsToken0 ? params.amountA : params.amountB;
+  const amount1Desired = aIsToken0 ? params.amountB : params.amountA;
+
+  const { tickLower, tickUpper } = fullRangeTicks(params.tickSpacing);
+
+  return {
+    token0,
+    token1,
+    amount0Desired,
+    amount1Desired,
+    tickLower,
+    tickUpper,
+  };
+}

--- a/src/execution/pool-creation.ts
+++ b/src/execution/pool-creation.ts
@@ -125,6 +125,9 @@ function abiEncodeInt24(value: number): string {
 }
 
 function abiEncodeUint8(value: number): string {
+  if (value < 0 || value > 255 || !Number.isInteger(value)) {
+    throw new Error(`abiEncodeUint8: value ${value} out of range [0, 255]`);
+  }
   return value.toString(16).padStart(64, "0");
 }
 

--- a/src/execution/pool-creation.ts
+++ b/src/execution/pool-creation.ts
@@ -22,9 +22,7 @@ import { conductorPoolCreationAbi } from "./abis/conductorPoolCreation";
 import { sortTokens } from "./pool";
 import { fullRangeTicks } from "./price-math";
 
-// ---------------------------------------------------------------------------
 // Types
-// ---------------------------------------------------------------------------
 
 /** EIP-2612 permit signature data for Conductor pool creation. */
 export interface PermitSignature {
@@ -62,9 +60,7 @@ export interface CreatePoolParams {
   feeRecipient: string;
 }
 
-// ---------------------------------------------------------------------------
 // Public API
-// ---------------------------------------------------------------------------
 
 /**
  * Encode calldata for Conductor.createBTCPool().

--- a/src/execution/pool-creation.ts
+++ b/src/execution/pool-creation.ts
@@ -130,7 +130,7 @@ function abiEncodeUint8(value: number): string {
 
 function abiEncodeBytes32(hex: string): string {
   const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
-  return clean.padEnd(64, "0");
+  return clean.padStart(64, "0");
 }
 
 // ---------------------------------------------------------------------------
@@ -191,12 +191,8 @@ export function encodeCreateBTCPool(params: CreateBTCPoolParams): {
     abiEncodeBytes32(params.permit.r) +
     abiEncodeBytes32(params.permit.s);
 
-  // ABI encoding with tuple offsets
-  const paramsOffset = abiEncodeUint256(64n); // offset to first tuple (2 * 32 bytes)
-  const permitOffset = abiEncodeUint256(BigInt(64 + poolParams.length / 2)); // offset to second tuple
-
-  const calldata =
-    SEL_CREATE_BTC_POOL + paramsOffset + permitOffset + poolParams + permitData;
+  // Both tuples contain only static types — encode inline without offset words.
+  const calldata = SEL_CREATE_BTC_POOL + poolParams + permitData;
 
   return { calldata: "0x" + calldata.replace(/^0x/, ""), wbtcAmountWei: params.wbtcAmount };
 }

--- a/src/execution/pool-creation.ts
+++ b/src/execution/pool-creation.ts
@@ -1,28 +1,24 @@
 /**
  * Conductor Pool Creation Helpers
  *
- * ABI encoding for Conductor.createPool() and Conductor.createBTCPool().
- * These build the calldata that goes into a deposit-and-execute intent.
+ * ABI encoding for Conductor.createBTCPool() using viem.
  *
  * @example
  * ```typescript
  * import { encodeCreateBTCPool } from "@flashnet/sdk/execution";
  *
- * const calldata = encodeCreateBTCPool({
- *   wbtcAddress: "0x...",
- *   otherTokenAddress: "0x...",
- *   fee: 3000,
- *   tickSpacing: 60,
- *   sqrtPriceX96: 79228162514264337593543950336n,
- *   wbtcAmount: 1000000000000000000n,
- *   otherAmount: 1000000000000000000n,
- *   hostId: "0x...",
- *   feeRecipient: "0x...",
+ * const { calldata, wbtcAmountWei } = encodeCreateBTCPool({
+ *   wbtcAddress: "0x...", otherTokenAddress: "0x...",
+ *   fee: 3000, tickSpacing: 60, sqrtPriceX96: 79228162514264337593543950336n,
+ *   wbtcAmount: 1000000000000000000n, otherAmount: 1000000000000000000n,
+ *   hostId: "0x...", feeRecipient: "0x...",
  *   permit: { value: 1000n, deadline: 9999999999n, v: 27, r: "0x...", s: "0x..." },
  * });
  * ```
  */
 
+import { encodeFunctionData } from "viem";
+import { conductorPoolCreationAbi } from "./abis/conductorPoolCreation";
 import { sortTokens } from "./pool";
 import { fullRangeTicks } from "./price-math";
 
@@ -41,109 +37,30 @@ export interface PermitSignature {
 
 /** Parameters for creating a BTC + ERC-20 pool via Conductor. */
 export interface CreateBTCPoolParams {
-  /** WBTC contract address. */
   wbtcAddress: string;
-  /** The other token address. */
   otherTokenAddress: string;
-  /** Fee tier (e.g. 500, 3000, 10000). */
   fee: number;
-  /** Tick spacing for the fee tier. */
   tickSpacing: number;
-  /** Initial sqrtPriceX96 for the pool. */
   sqrtPriceX96: bigint;
-  /** Amount of WBTC to provide (in wei). */
   wbtcAmount: bigint;
-  /** Amount of the other token to provide (in base units). */
   otherAmount: bigint;
-  /** Host identifier (32-byte hex). */
   hostId: string;
-  /** Address to receive host fees. */
   feeRecipient: string;
-  /** EIP-2612 permit for the non-BTC token. */
   permit: PermitSignature;
 }
 
 /** Parameters for creating an ERC-20 only pool via Conductor (Permit2). */
 export interface CreatePoolParams {
-  /** First token address. */
   tokenA: string;
-  /** Second token address. */
   tokenB: string;
-  /** Fee tier. */
   fee: number;
-  /** Tick spacing for the fee tier. */
   tickSpacing: number;
-  /** Initial sqrtPriceX96. */
   sqrtPriceX96: bigint;
-  /** Amount of tokenA (in base units). */
   amountA: bigint;
-  /** Amount of tokenB (in base units). */
   amountB: bigint;
-  /** Host identifier (32-byte hex). */
   hostId: string;
-  /** Address to receive host fees. */
   feeRecipient: string;
 }
-
-// ---------------------------------------------------------------------------
-// ABI encoding helpers
-// ---------------------------------------------------------------------------
-
-function abiEncodeAddress(address: string): string {
-  const clean = address.startsWith("0x") ? address.slice(2) : address;
-  return clean.toLowerCase().padStart(64, "0");
-}
-
-function abiEncodeUint256(value: bigint): string {
-  if (value < 0n) throw new Error("abiEncodeUint256: value must be non-negative");
-  if (value >= 1n << 256n)
-    throw new Error("abiEncodeUint256: value exceeds uint256 max");
-  return value.toString(16).padStart(64, "0");
-}
-
-function abiEncodeUint160(value: bigint): string {
-  if (value >= 1n << 160n)
-    throw new Error("abiEncodeUint160: value exceeds uint160 max");
-  return value.toString(16).padStart(64, "0");
-}
-
-function abiEncodeUint24(value: number): string {
-  if (value < 0 || value >= 2 ** 24)
-    throw new Error("abiEncodeUint24: value out of range");
-  return value.toString(16).padStart(64, "0");
-}
-
-function abiEncodeInt24(value: number): string {
-  if (value < -(2 ** 23) || value >= 2 ** 23)
-    throw new Error("abiEncodeInt24: value out of range");
-  if (value >= 0) {
-    return value.toString(16).padStart(64, "0");
-  }
-  // Two's complement for negative values
-  const twos = BigInt(value) + (1n << 256n);
-  return twos.toString(16).padStart(64, "0");
-}
-
-function abiEncodeUint8(value: number): string {
-  if (value < 0 || value > 255 || !Number.isInteger(value)) {
-    throw new Error(`abiEncodeUint8: value ${value} out of range [0, 255]`);
-  }
-  return value.toString(16).padStart(64, "0");
-}
-
-function abiEncodeBytes32(hex: string): string {
-  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
-  return clean.padStart(64, "0");
-}
-
-// ---------------------------------------------------------------------------
-// Function selectors
-// ---------------------------------------------------------------------------
-
-/**
- * createBTCPool((address,address,uint24,uint160,int24,int24,uint256,uint256,uint256,uint256,bytes32,address),(uint256,uint256,uint8,bytes32,bytes32))
- */
-const SEL_CREATE_BTC_POOL = "0xb1e2eda2";
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -152,8 +69,6 @@ const SEL_CREATE_BTC_POOL = "0xb1e2eda2";
 /**
  * Encode calldata for Conductor.createBTCPool().
  * Handles token sorting, full-range tick calculation, and permit struct encoding.
- *
- * @returns Object with calldata (0x-prefixed hex) and wbtcAmountWei for the tx value field
  */
 export function encodeCreateBTCPool(params: CreateBTCPoolParams): {
   calldata: string;
@@ -171,42 +86,40 @@ export function encodeCreateBTCPool(params: CreateBTCPoolParams): {
 
   const { tickLower, tickUpper } = fullRangeTicks(params.tickSpacing);
 
-  // Encode the CreatePoolParams tuple (12 fields)
-  const poolParams =
-    abiEncodeAddress(token0) +
-    abiEncodeAddress(token1) +
-    abiEncodeUint24(params.fee) +
-    abiEncodeUint160(params.sqrtPriceX96) +
-    abiEncodeInt24(tickLower) +
-    abiEncodeInt24(tickUpper) +
-    abiEncodeUint256(amount0Desired) +
-    abiEncodeUint256(amount1Desired) +
-    abiEncodeUint256(0n) + // amount0Min
-    abiEncodeUint256(0n) + // amount1Min
-    abiEncodeBytes32(params.hostId) +
-    abiEncodeAddress(params.feeRecipient);
+  const calldata = encodeFunctionData({
+    abi: conductorPoolCreationAbi,
+    functionName: "createBTCPool",
+    args: [
+      {
+        token0: token0 as `0x${string}`,
+        token1: token1 as `0x${string}`,
+        fee: params.fee,
+        sqrtPriceX96: params.sqrtPriceX96,
+        tickLower,
+        tickUpper,
+        amount0Desired,
+        amount1Desired,
+        amount0Min: 0n,
+        amount1Min: 0n,
+        hostId: params.hostId as `0x${string}`,
+        feeRecipient: params.feeRecipient as `0x${string}`,
+      },
+      {
+        value: params.permit.value,
+        deadline: params.permit.deadline,
+        v: params.permit.v,
+        r: params.permit.r as `0x${string}`,
+        s: params.permit.s as `0x${string}`,
+      },
+    ],
+  });
 
-  // Encode the ERC20PermitSig tuple (5 fields)
-  const permitData =
-    abiEncodeUint256(params.permit.value) +
-    abiEncodeUint256(params.permit.deadline) +
-    abiEncodeUint8(params.permit.v) +
-    abiEncodeBytes32(params.permit.r) +
-    abiEncodeBytes32(params.permit.s);
-
-  // Both tuples contain only static types — encode inline without offset words.
-  const calldata = SEL_CREATE_BTC_POOL + poolParams + permitData;
-
-  return { calldata: "0x" + calldata.replace(/^0x/, ""), wbtcAmountWei: params.wbtcAmount };
+  return { calldata, wbtcAmountWei: params.wbtcAmount };
 }
 
 /**
- * Encode calldata for Conductor.createPool() (ERC20-only pools via Permit2).
- *
- * Note: This function encodes the pool parameters only. The Permit2 batch
- * signature must be constructed separately based on the partner's signing flow.
- *
- * @returns Encoded pool parameters (not full calldata — Permit2 sig appended by caller)
+ * Encode pool parameters for Conductor.createPool() (ERC20-only pools via Permit2).
+ * Returns sorted token info for the caller to build the full Permit2 transaction.
  */
 export function encodeCreatePoolParams(params: CreatePoolParams): {
   token0: string;
@@ -217,18 +130,15 @@ export function encodeCreatePoolParams(params: CreatePoolParams): {
   tickUpper: number;
 } {
   const [token0, token1] = sortTokens(params.tokenA, params.tokenB);
-  const aIsToken0 = token0.toLowerCase() === params.tokenA.toLowerCase();
-
-  const amount0Desired = aIsToken0 ? params.amountA : params.amountB;
-  const amount1Desired = aIsToken0 ? params.amountB : params.amountA;
+  const isSwapped = token0.toLowerCase() !== params.tokenA.toLowerCase();
 
   const { tickLower, tickUpper } = fullRangeTicks(params.tickSpacing);
 
   return {
     token0,
     token1,
-    amount0Desired,
-    amount1Desired,
+    amount0Desired: isSwapped ? params.amountB : params.amountA,
+    amount1Desired: isSwapped ? params.amountA : params.amountB,
     tickLower,
     tickUpper,
   };

--- a/src/execution/pool.ts
+++ b/src/execution/pool.ts
@@ -1,149 +1,69 @@
 /**
- * Uniswap V3 Pool Query Helpers
+ * Uniswap V3 Pool Queries
  *
- * Zero-dependency pool query utilities using raw JSON-RPC calls.
- * Provides pool existence checks, state queries, and token sorting.
+ * Read-only queries for pool existence, state, and pricing using viem.
  *
  * @example
  * ```typescript
- * import { getPoolAddress, fetchPoolInfo, sortTokens } from "@flashnet/sdk/execution";
- *
- * const pool = await getPoolAddress(rpcUrl, factory, tokenA, tokenB, 3000);
- * if (pool) {
- *   const info = await fetchPoolInfo(rpcUrl, pool);
+ * const poolAddr = await getPoolAddress(rpcUrl, factoryAddr, tokenA, tokenB, 3000);
+ * if (poolAddr) {
+ *   const info = await fetchPoolInfo(rpcUrl, poolAddr);
  *   console.log(`Price: sqrtPriceX96=${info.sqrtPriceX96}`);
  * }
  * ```
  */
 
+import {
+  createPublicClient,
+  http,
+  zeroAddress,
+  type Address,
+  type PublicClient,
+  type Transport,
+  type Chain,
+} from "viem";
+import { uniswapV3FactoryAbi, uniswapV3PoolAbi } from "./abis/uniswapV3";
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-/** Uniswap V3 pool state snapshot. */
 export interface PoolInfo {
-  /** Pool contract address. */
   address: string;
-  /** Lower-sorted token address. */
   token0: string;
-  /** Higher-sorted token address. */
   token1: string;
-  /** Current sqrtPriceX96 (Q64.96 fixed-point). */
   sqrtPriceX96: bigint;
-  /** Current tick index. */
   tick: number;
-  /** Current in-range liquidity. */
   liquidity: bigint;
 }
 
 // ---------------------------------------------------------------------------
-// ABI selectors
+// Client cache
 // ---------------------------------------------------------------------------
 
-/** keccak256("getPool(address,address,uint24)") */
-const SEL_GET_POOL = "0x1698ee82";
-/** keccak256("slot0()") */
-const SEL_SLOT0 = "0x3850c7bd";
-/** keccak256("liquidity()") */
-const SEL_LIQUIDITY = "0x1a686502";
-/** keccak256("token0()") */
-const SEL_TOKEN0 = "0x0dfe1681";
-/** keccak256("token1()") */
-const SEL_TOKEN1 = "0xd21220a7";
+const clientCache = new Map<string, PublicClient<Transport, Chain | undefined>>();
 
-// ---------------------------------------------------------------------------
-// Raw JSON-RPC
-// ---------------------------------------------------------------------------
-
-let rpcIdCounter = 10000;
-
-async function ethCall(
-  rpcUrl: string,
-  to: string,
-  data: string
-): Promise<string> {
-  const resp = await fetch(rpcUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      id: rpcIdCounter++,
-      method: "eth_call",
-      params: [{ to, data }, "latest"],
-    }),
-  });
-
-  const json = (await resp.json()) as {
-    result?: string;
-    error?: { message: string };
-  };
-  if (json.error) {
-    throw new Error(`eth_call failed: ${json.error.message}`);
+function getClient(rpcUrl: string): PublicClient<Transport, Chain | undefined> {
+  let client = clientCache.get(rpcUrl);
+  if (!client) {
+    client = createPublicClient({ transport: http(rpcUrl) });
+    clientCache.set(rpcUrl, client);
   }
-  return json.result ?? "0x";
-}
-
-// ---------------------------------------------------------------------------
-// ABI encoding/decoding
-// ---------------------------------------------------------------------------
-
-const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
-
-function padAddress(address: string): string {
-  const clean = address.startsWith("0x") ? address.slice(2) : address;
-  return clean.toLowerCase().padStart(64, "0");
-}
-
-function padUint24(value: number): string {
-  return value.toString(16).padStart(64, "0");
-}
-
-function decodeAddress(hex: string, offset: number): string {
-  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
-  return "0x" + clean.substring(offset * 2 + 24, offset * 2 + 64);
-}
-
-function decodeUint(hex: string, offset: number): bigint {
-  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
-  const word = clean.substring(offset * 2, offset * 2 + 64);
-  return BigInt("0x" + (word.replace(/^0+/, "") || "0"));
-}
-
-function decodeInt(hex: string, offset: number): number {
-  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
-  const word = clean.substring(offset * 2, offset * 2 + 64);
-  const value = BigInt("0x" + word);
-  // Handle signed int24: if bit 23 is set, value is negative
-  if (value >= 1n << 255n) {
-    return Number(value - (1n << 256n));
-  }
-  return Number(value);
+  return client;
 }
 
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
-/**
- * Sort two token addresses into Uniswap's canonical order (lower address first).
- *
- * @param a - First token address
- * @param b - Second token address
- * @returns Tuple of [token0, token1] in sorted order
- */
+/** Canonical token sorting (lower address first). */
 export function sortTokens(a: string, b: string): [string, string] {
   return a.toLowerCase() < b.toLowerCase() ? [a, b] : [b, a];
 }
 
 /**
- * Look up the Uniswap V3 pool address for a token pair and fee tier.
- *
- * @param rpcUrl - JSON-RPC endpoint URL
- * @param factoryAddress - Uniswap V3 Factory contract address
- * @param tokenA - First token address
- * @param tokenB - Second token address
- * @param fee - Fee tier (e.g. 500, 3000, 10000)
- * @returns Pool address, or null if no pool exists
+ * Look up a Uniswap V3 pool address via the Factory contract.
+ * Returns null if no pool exists for the given pair and fee.
  */
 export async function getPoolAddress(
   rpcUrl: string,
@@ -152,38 +72,49 @@ export async function getPoolAddress(
   tokenB: string,
   fee: number
 ): Promise<string | null> {
-  const data =
-    SEL_GET_POOL + padAddress(tokenA) + padAddress(tokenB) + padUint24(fee);
-  const result = await ethCall(rpcUrl, factoryAddress, data);
-  const pool = decodeAddress(result, 0);
-  if (pool === ZERO_ADDRESS) return null;
+  const client = getClient(rpcUrl);
+  const pool = await client.readContract({
+    address: factoryAddress as Address,
+    abi: uniswapV3FactoryAbi,
+    functionName: "getPool",
+    args: [tokenA as Address, tokenB as Address, fee],
+  });
+
+  if (pool === zeroAddress) return null;
   return pool;
 }
 
 /**
- * Fetch current state of a Uniswap V3 pool (price, tick, liquidity, tokens).
- *
- * @param rpcUrl - JSON-RPC endpoint URL
- * @param poolAddress - Pool contract address
- * @returns Pool state snapshot
+ * Fetch pool state (price, tick, liquidity, tokens) via multicall.
  */
 export async function fetchPoolInfo(
   rpcUrl: string,
   poolAddress: string
 ): Promise<PoolInfo> {
-  const [slot0Hex, liquidityHex, token0Hex, token1Hex] = await Promise.all([
-    ethCall(rpcUrl, poolAddress, SEL_SLOT0),
-    ethCall(rpcUrl, poolAddress, SEL_LIQUIDITY),
-    ethCall(rpcUrl, poolAddress, SEL_TOKEN0),
-    ethCall(rpcUrl, poolAddress, SEL_TOKEN1),
-  ]);
+  const client = getClient(rpcUrl);
+  const addr = poolAddress as Address;
+
+  const results = await client.multicall({
+    contracts: [
+      { address: addr, abi: uniswapV3PoolAbi, functionName: "slot0" },
+      { address: addr, abi: uniswapV3PoolAbi, functionName: "liquidity" },
+      { address: addr, abi: uniswapV3PoolAbi, functionName: "token0" },
+      { address: addr, abi: uniswapV3PoolAbi, functionName: "token1" },
+    ],
+  });
+
+  if (results[0].status !== "success") {
+    throw new Error(`Failed to read slot0 from pool ${poolAddress}`);
+  }
+
+  const [sqrtPriceX96, tick] = results[0].result;
 
   return {
     address: poolAddress,
-    token0: decodeAddress(token0Hex, 0),
-    token1: decodeAddress(token1Hex, 0),
-    sqrtPriceX96: decodeUint(slot0Hex, 0),
-    tick: decodeInt(slot0Hex, 32),
-    liquidity: decodeUint(liquidityHex, 0),
+    token0: results[2].status === "success" ? results[2].result : "",
+    token1: results[3].status === "success" ? results[3].result : "",
+    sqrtPriceX96,
+    tick,
+    liquidity: results[1].status === "success" ? results[1].result : 0n,
   };
 }

--- a/src/execution/pool.ts
+++ b/src/execution/pool.ts
@@ -13,16 +13,9 @@
  * ```
  */
 
-import {
-  createPublicClient,
-  http,
-  zeroAddress,
-  type Address,
-  type PublicClient,
-  type Transport,
-  type Chain,
-} from "viem";
+import { zeroAddress, type Address } from "viem";
 import { uniswapV3FactoryAbi, uniswapV3PoolAbi } from "./abis/uniswapV3";
+import { getClient } from "./rpc";
 
 // Types
 
@@ -33,19 +26,6 @@ export interface PoolInfo {
   sqrtPriceX96: bigint;
   tick: number;
   liquidity: bigint;
-}
-
-// Client cache
-
-const clientCache = new Map<string, PublicClient<Transport, Chain | undefined>>();
-
-function getClient(rpcUrl: string): PublicClient<Transport, Chain | undefined> {
-  let client = clientCache.get(rpcUrl);
-  if (!client) {
-    client = createPublicClient({ transport: http(rpcUrl) });
-    clientCache.set(rpcUrl, client);
-  }
-  return client;
 }
 
 // Public API

--- a/src/execution/pool.ts
+++ b/src/execution/pool.ts
@@ -24,9 +24,7 @@ import {
 } from "viem";
 import { uniswapV3FactoryAbi, uniswapV3PoolAbi } from "./abis/uniswapV3";
 
-// ---------------------------------------------------------------------------
 // Types
-// ---------------------------------------------------------------------------
 
 export interface PoolInfo {
   address: string;
@@ -37,9 +35,7 @@ export interface PoolInfo {
   liquidity: bigint;
 }
 
-// ---------------------------------------------------------------------------
 // Client cache
-// ---------------------------------------------------------------------------
 
 const clientCache = new Map<string, PublicClient<Transport, Chain | undefined>>();
 
@@ -52,9 +48,7 @@ function getClient(rpcUrl: string): PublicClient<Transport, Chain | undefined> {
   return client;
 }
 
-// ---------------------------------------------------------------------------
 // Public API
-// ---------------------------------------------------------------------------
 
 /** Canonical token sorting (lower address first). */
 export function sortTokens(a: string, b: string): [string, string] {

--- a/src/execution/pool.ts
+++ b/src/execution/pool.ts
@@ -1,0 +1,189 @@
+/**
+ * Uniswap V3 Pool Query Helpers
+ *
+ * Zero-dependency pool query utilities using raw JSON-RPC calls.
+ * Provides pool existence checks, state queries, and token sorting.
+ *
+ * @example
+ * ```typescript
+ * import { getPoolAddress, fetchPoolInfo, sortTokens } from "@flashnet/sdk/execution";
+ *
+ * const pool = await getPoolAddress(rpcUrl, factory, tokenA, tokenB, 3000);
+ * if (pool) {
+ *   const info = await fetchPoolInfo(rpcUrl, pool);
+ *   console.log(`Price: sqrtPriceX96=${info.sqrtPriceX96}`);
+ * }
+ * ```
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Uniswap V3 pool state snapshot. */
+export interface PoolInfo {
+  /** Pool contract address. */
+  address: string;
+  /** Lower-sorted token address. */
+  token0: string;
+  /** Higher-sorted token address. */
+  token1: string;
+  /** Current sqrtPriceX96 (Q64.96 fixed-point). */
+  sqrtPriceX96: bigint;
+  /** Current tick index. */
+  tick: number;
+  /** Current in-range liquidity. */
+  liquidity: bigint;
+}
+
+// ---------------------------------------------------------------------------
+// ABI selectors
+// ---------------------------------------------------------------------------
+
+/** keccak256("getPool(address,address,uint24)") */
+const SEL_GET_POOL = "0x1698ee82";
+/** keccak256("slot0()") */
+const SEL_SLOT0 = "0x3850c7bd";
+/** keccak256("liquidity()") */
+const SEL_LIQUIDITY = "0x1a686502";
+/** keccak256("token0()") */
+const SEL_TOKEN0 = "0x0dfe1681";
+/** keccak256("token1()") */
+const SEL_TOKEN1 = "0xd21220a7";
+
+// ---------------------------------------------------------------------------
+// Raw JSON-RPC
+// ---------------------------------------------------------------------------
+
+let rpcIdCounter = 10000;
+
+async function ethCall(
+  rpcUrl: string,
+  to: string,
+  data: string
+): Promise<string> {
+  const resp = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: rpcIdCounter++,
+      method: "eth_call",
+      params: [{ to, data }, "latest"],
+    }),
+  });
+
+  const json = (await resp.json()) as {
+    result?: string;
+    error?: { message: string };
+  };
+  if (json.error) {
+    throw new Error(`eth_call failed: ${json.error.message}`);
+  }
+  return json.result ?? "0x";
+}
+
+// ---------------------------------------------------------------------------
+// ABI encoding/decoding
+// ---------------------------------------------------------------------------
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+function padAddress(address: string): string {
+  const clean = address.startsWith("0x") ? address.slice(2) : address;
+  return clean.toLowerCase().padStart(64, "0");
+}
+
+function padUint24(value: number): string {
+  return value.toString(16).padStart(64, "0");
+}
+
+function decodeAddress(hex: string, offset: number): string {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  return "0x" + clean.substring(offset * 2 + 24, offset * 2 + 64);
+}
+
+function decodeUint(hex: string, offset: number): bigint {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  const word = clean.substring(offset * 2, offset * 2 + 64);
+  return BigInt("0x" + (word.replace(/^0+/, "") || "0"));
+}
+
+function decodeInt(hex: string, offset: number): number {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  const word = clean.substring(offset * 2, offset * 2 + 64);
+  const value = BigInt("0x" + word);
+  // Handle signed int24: if bit 23 is set, value is negative
+  if (value >= 1n << 255n) {
+    return Number(value - (1n << 256n));
+  }
+  return Number(value);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Sort two token addresses into Uniswap's canonical order (lower address first).
+ *
+ * @param a - First token address
+ * @param b - Second token address
+ * @returns Tuple of [token0, token1] in sorted order
+ */
+export function sortTokens(a: string, b: string): [string, string] {
+  return a.toLowerCase() < b.toLowerCase() ? [a, b] : [b, a];
+}
+
+/**
+ * Look up the Uniswap V3 pool address for a token pair and fee tier.
+ *
+ * @param rpcUrl - JSON-RPC endpoint URL
+ * @param factoryAddress - Uniswap V3 Factory contract address
+ * @param tokenA - First token address
+ * @param tokenB - Second token address
+ * @param fee - Fee tier (e.g. 500, 3000, 10000)
+ * @returns Pool address, or null if no pool exists
+ */
+export async function getPoolAddress(
+  rpcUrl: string,
+  factoryAddress: string,
+  tokenA: string,
+  tokenB: string,
+  fee: number
+): Promise<string | null> {
+  const data =
+    SEL_GET_POOL + padAddress(tokenA) + padAddress(tokenB) + padUint24(fee);
+  const result = await ethCall(rpcUrl, factoryAddress, data);
+  const pool = decodeAddress(result, 0);
+  if (pool === ZERO_ADDRESS) return null;
+  return pool;
+}
+
+/**
+ * Fetch current state of a Uniswap V3 pool (price, tick, liquidity, tokens).
+ *
+ * @param rpcUrl - JSON-RPC endpoint URL
+ * @param poolAddress - Pool contract address
+ * @returns Pool state snapshot
+ */
+export async function fetchPoolInfo(
+  rpcUrl: string,
+  poolAddress: string
+): Promise<PoolInfo> {
+  const [slot0Hex, liquidityHex, token0Hex, token1Hex] = await Promise.all([
+    ethCall(rpcUrl, poolAddress, SEL_SLOT0),
+    ethCall(rpcUrl, poolAddress, SEL_LIQUIDITY),
+    ethCall(rpcUrl, poolAddress, SEL_TOKEN0),
+    ethCall(rpcUrl, poolAddress, SEL_TOKEN1),
+  ]);
+
+  return {
+    address: poolAddress,
+    token0: decodeAddress(token0Hex, 0),
+    token1: decodeAddress(token1Hex, 0),
+    sqrtPriceX96: decodeUint(slot0Hex, 0),
+    tick: decodeInt(slot0Hex, 32),
+    liquidity: decodeUint(liquidityHex, 0),
+  };
+}

--- a/src/execution/price-math.ts
+++ b/src/execution/price-math.ts
@@ -1,0 +1,95 @@
+/**
+ * Uniswap V3 Price Math Utilities
+ *
+ * Conversion functions between human-readable prices and Uniswap V3's
+ * sqrtPriceX96 / tick representations. Zero dependencies.
+ *
+ * @example
+ * ```typescript
+ * import { priceToSqrtPriceX96, sqrtPriceX96ToPrice, fullRangeTicks } from "@flashnet/sdk/execution";
+ *
+ * const sqrtPrice = priceToSqrtPriceX96(1.5, 18, 8); // 1.5 token1 per token0
+ * const price = sqrtPriceX96ToPrice(sqrtPrice, 18, 8);
+ * const { tickLower, tickUpper } = fullRangeTicks(60);
+ * ```
+ */
+
+/** Uniswap V3 fee tiers with their tick spacings. */
+export const FEE_TIERS = [
+  { fee: 500, label: "0.05%", tickSpacing: 10 },
+  { fee: 3000, label: "0.3%", tickSpacing: 60 },
+  { fee: 10000, label: "1%", tickSpacing: 200 },
+] as const;
+
+/** Q96 constant: 2^96 */
+const Q96 = 1n << 96n;
+
+/**
+ * Convert a human-readable price to Uniswap V3 sqrtPriceX96.
+ *
+ * @param price - Price of token1 in terms of token0 (e.g. 1.5 means 1 token0 = 1.5 token1)
+ * @param decimals0 - Decimals of token0
+ * @param decimals1 - Decimals of token1
+ * @returns sqrtPriceX96 as bigint (Q64.96 fixed-point)
+ */
+export function priceToSqrtPriceX96(
+  price: number,
+  decimals0: number,
+  decimals1: number
+): bigint {
+  const PRECISION = 1e15;
+  const decDiff = decimals0 - decimals1;
+
+  if (decDiff >= 0) {
+    const sqrtPrice = Math.sqrt(price);
+    const sqrtScale = Math.sqrt(10 ** Math.min(decDiff, 30));
+    const sPrecise = BigInt(Math.round(sqrtPrice * PRECISION));
+    const scalePrecise = BigInt(Math.round(sqrtScale * PRECISION));
+    const PREC = BigInt(PRECISION);
+    return (sPrecise * scalePrecise * Q96) / (PREC * PREC);
+  } else {
+    const sqrtPrice = Math.sqrt(price);
+    const sqrtScale = BigInt(
+      Math.round(Math.sqrt(10 ** Math.min(-decDiff, 30)) * PRECISION)
+    );
+    const sPrecise = BigInt(Math.round(sqrtPrice * PRECISION));
+    return (sPrecise * Q96) / sqrtScale;
+  }
+}
+
+/**
+ * Convert Uniswap V3 sqrtPriceX96 back to a human-readable price.
+ *
+ * @param sqrtPriceX96 - sqrtPriceX96 (Q64.96 fixed-point)
+ * @param decimals0 - Decimals of token0
+ * @param decimals1 - Decimals of token1
+ * @returns Human-readable price (token1 per token0)
+ */
+export function sqrtPriceX96ToPrice(
+  sqrtPriceX96: bigint,
+  decimals0: number,
+  decimals1: number
+): number {
+  const SCALE = 10n ** 18n;
+  const raw = Number(
+    (sqrtPriceX96 * sqrtPriceX96 * SCALE) / (Q96 * Q96)
+  );
+  return (raw / 1e18) * 10 ** (decimals1 - decimals0);
+}
+
+/**
+ * Compute full-range tick bounds for a given tick spacing.
+ *
+ * @param tickSpacing - The pool's tick spacing (e.g. 10, 60, 200)
+ * @returns { tickLower, tickUpper } aligned to the tick spacing
+ */
+export function fullRangeTicks(tickSpacing: number): {
+  tickLower: number;
+  tickUpper: number;
+} {
+  const MIN_TICK = -887272;
+  const MAX_TICK = 887272;
+  const tickLower = Math.ceil(MIN_TICK / tickSpacing) * tickSpacing;
+  const tickUpper = Math.floor(MAX_TICK / tickSpacing) * tickSpacing;
+  return { tickLower, tickUpper };
+}

--- a/src/execution/rpc.ts
+++ b/src/execution/rpc.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared viem PublicClient factory with Multicall3 support.
+ */
+
+import {
+  createPublicClient,
+  defineChain,
+  http,
+  type PublicClient,
+} from "viem";
+
+const MULTICALL3_ADDRESS = "0xcA11bde05977b3631167028862bE2a173976CA11" as const;
+
+const clientCache = new Map<string, PublicClient>();
+
+export function getClient(rpcUrl: string): PublicClient {
+  let client = clientCache.get(rpcUrl);
+  if (!client) {
+    const chain = defineChain({
+      id: 0,
+      name: "flashnet",
+      nativeCurrency: { name: "BTC", symbol: "BTC", decimals: 18 },
+      rpcUrls: { default: { http: [rpcUrl] } },
+      contracts: {
+        multicall3: { address: MULTICALL3_ADDRESS },
+      },
+    });
+    client = createPublicClient({ chain, transport: http(rpcUrl) });
+    clientCache.set(rpcUrl, client);
+  }
+  return client;
+}

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -1,0 +1,106 @@
+/**
+ * Flashnet Execution Layer Types
+ *
+ * Types for interacting with the Flashnet execution gateway.
+ * These map directly to the Rust gateway API types in flashnet-execution.
+ */
+
+/** Asset type for a deposit from Spark into the EVM. */
+export type DepositAsset =
+  | { type: "btc" }
+  | { type: "token"; tokenId: string };
+
+/** A single deposit funding an intent from a Spark transfer. */
+export interface Deposit {
+  /** Spark transfer ID (hex string, no 0x prefix). Bitcoin: 16 bytes, Token: 32 bytes. */
+  sparkTransferId: string;
+  /** The asset being deposited. */
+  asset: DepositAsset;
+  /** Amount in base units (sats for BTC, smallest unit for tokens). */
+  amount: number;
+}
+
+/** Request to submit a deposit-only intent (credit recipient without executing). */
+export interface DepositIntentParams {
+  chainId: number;
+  deposits: Deposit[];
+  /** EVM address to credit with the deposited funds (0x-prefixed). */
+  recipient: string;
+}
+
+/** Request to submit a deposit-and-execute intent. */
+export interface ExecuteIntentParams {
+  chainId: number;
+  deposits: Deposit[];
+  /** Hex-encoded signed EVM transaction (RLP-serialized, 0x-prefixed). */
+  signedTx: string;
+}
+
+/** Response from the execution gateway after submitting an intent. */
+export interface ExecuteResponse {
+  /** Unique handle for this submission attempt. */
+  submissionId: string;
+  /** Canonical identifier of the logical intent content. */
+  intentId: string;
+  /** Current status of the intent. */
+  status: string;
+}
+
+/** Configuration for the execution client. */
+export interface ExecutionClientConfig {
+  /** Base URL of the execution gateway (e.g. "http://localhost:8080"). */
+  gatewayUrl: string;
+}
+
+/**
+ * Signer interface for the execution client.
+ *
+ * Signs raw byte arrays (SHA-256 hash of the canonical intent message)
+ * and returns a DER-encoded secp256k1 ECDSA signature as hex.
+ */
+export interface ExecutionSigner {
+  /** Compressed secp256k1 public key as hex (66 chars, no 0x prefix). */
+  getPublicKey(): string | Promise<string>;
+
+  /**
+   * Sign a UTF-8 message string.
+   *
+   * The implementation must:
+   * 1. UTF-8 encode the message to bytes
+   * 2. SHA-256 hash the bytes
+   * 3. Sign the hash with secp256k1 ECDSA
+   * 4. Return the DER-encoded signature as hex (no 0x prefix)
+   */
+  signMessage(message: string): string | Promise<string>;
+}
+
+/**
+ * Canonical transfer entry in the signed intent message.
+ * Must match the Rust CanonicalTransferEntry serialization (camelCase).
+ */
+export interface CanonicalTransferEntry {
+  transferId: string;
+  amountSats: number;
+  assetType: "NativeSats" | "BridgedToken";
+  tokenId?: string;
+}
+
+/**
+ * Canonical intent action in the signed intent message.
+ * Must match the Rust CanonicalIntentAction serialization
+ * (camelCase, internally tagged with "type").
+ */
+export type CanonicalIntentAction =
+  | { type: "deposit"; recipient: string }
+  | { type: "execute"; signedTxHash: string };
+
+/**
+ * Canonical intent message that gets signed by the client.
+ * Must match the Rust CanonicalIntentMessage serialization (camelCase).
+ */
+export interface CanonicalIntentMessage {
+  chainId: number;
+  transfers: CanonicalTransferEntry[];
+  action: CanonicalIntentAction;
+  nonce: string;
+}

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -16,8 +16,8 @@ export interface Deposit {
   sparkTransferId: string;
   /** The asset being deposited. */
   asset: DepositAsset;
-  /** Amount in base units (sats for BTC, smallest unit for tokens). */
-  amount: number;
+  /** Amount in base units (sats for BTC, smallest unit for tokens). Use bigint for precision with large token amounts. */
+  amount: number | bigint;
 }
 
 /** Request to submit a deposit-only intent (credit recipient without executing). */
@@ -80,7 +80,7 @@ export interface ExecutionSigner {
  */
 export interface CanonicalTransferEntry {
   transferId: string;
-  amountSats: number;
+  amountSats: number | bigint;
   assetType: "NativeSats" | "BridgedToken";
   tokenId?: string;
 }

--- a/tests/e2e-execution.ts
+++ b/tests/e2e-execution.ts
@@ -101,7 +101,7 @@ async function testHealthCheck(): Promise<void> {
 
   try {
     const health = await client.health();
-    assert(health !== undefined, "Health endpoint responds");
+    assert(health === true, "Health endpoint returns true");
     console.log(`  Health response:`, health);
   } catch (e) {
     failed++;

--- a/tests/e2e-execution.ts
+++ b/tests/e2e-execution.ts
@@ -1,0 +1,309 @@
+/**
+ * E2E Test Script for Flashnet Execution Client
+ *
+ * Tests the full execution client flow against a running localnet:
+ * - Authentication (challenge-response)
+ * - EVM read queries (token info, balances)
+ * - Deposit intent submission
+ * - Deposit-and-execute intent submission (Conductor swap)
+ * - Health check
+ *
+ * Prerequisites:
+ *   1. Start localnet: `cargo run -p flashnet-localnet -- --data-dir /tmp/flashnet-localnet`
+ *   2. Set GATEWAY_URL (default: http://localhost:8080)
+ *   3. Set RPC_URL (default: http://localhost:8545)
+ *
+ * Usage:
+ *   GATEWAY_URL=http://localhost:8080 bun run tests/e2e-execution.ts
+ */
+
+import {
+  ExecutionClient,
+  Conductor,
+  fetchTokenInfo,
+  fetchTokenBalance,
+  fetchNativeBalance,
+  fetchNonce,
+  getPoolAddress,
+  fetchPoolInfo,
+  sortTokens,
+  priceToSqrtPriceX96,
+  sqrtPriceX96ToPrice,
+  fullRangeTicks,
+  FEE_TIERS,
+  type ExecutionSigner,
+  type Deposit,
+  type ConductorConfig,
+  type EvmTransactionSigner,
+  type UnsignedTransaction,
+} from "../src/execution";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const GATEWAY_URL = process.env.GATEWAY_URL ?? "http://localhost:8080";
+const RPC_URL = process.env.RPC_URL ?? "http://localhost:8545";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition: boolean, message: string): void {
+  if (condition) {
+    passed++;
+    console.log(`  ✓ ${message}`);
+  } else {
+    failed++;
+    console.error(`  ✗ FAIL: ${message}`);
+  }
+}
+
+async function assertThrows(
+  fn: () => Promise<unknown>,
+  message: string
+): Promise<void> {
+  try {
+    await fn();
+    failed++;
+    console.error(`  ✗ FAIL: Expected error: ${message}`);
+  } catch {
+    passed++;
+    console.log(`  ✓ ${message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mock signers (for testing structure, not real crypto)
+// ---------------------------------------------------------------------------
+
+const mockIntentSigner: ExecutionSigner = {
+  getPublicKey() {
+    // 33-byte compressed secp256k1 key (hex, no 0x)
+    return "02" + "ab".repeat(32);
+  },
+  signMessage(_message: string) {
+    // Return a fake DER signature for structural testing
+    return "30" + "44" + "02" + "20" + "ff".repeat(32) + "02" + "20" + "ff".repeat(32);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Test suites
+// ---------------------------------------------------------------------------
+
+async function testHealthCheck(): Promise<void> {
+  console.log("\n--- Health Check ---");
+  const client = new ExecutionClient({ gatewayUrl: GATEWAY_URL }, mockIntentSigner);
+
+  try {
+    const health = await client.health();
+    assert(health !== undefined, "Health endpoint responds");
+    console.log(`  Health response:`, health);
+  } catch (e) {
+    failed++;
+    console.error(`  ✗ Health check failed: ${e}`);
+  }
+}
+
+async function testAuthentication(): Promise<void> {
+  console.log("\n--- Authentication ---");
+  const client = new ExecutionClient({ gatewayUrl: GATEWAY_URL }, mockIntentSigner);
+
+  try {
+    const token = await client.authenticate();
+    assert(typeof token === "string" && token.length > 0, "Authentication returns access token");
+    assert(client.getAccessToken() === token, "Access token is stored");
+  } catch (e) {
+    failed++;
+    console.error(`  ✗ Authentication failed: ${e}`);
+    console.error(`  (Is the gateway running at ${GATEWAY_URL}?)`);
+  }
+}
+
+async function testEvmReadHelpers(): Promise<void> {
+  console.log("\n--- EVM Read Helpers ---");
+
+  // Test fetchNativeBalance (always works on any chain)
+  try {
+    const balance = await fetchNativeBalance(RPC_URL, "0x0000000000000000000000000000000000000000");
+    assert(typeof balance === "bigint", `fetchNativeBalance returns bigint (${balance})`);
+  } catch (e) {
+    failed++;
+    console.error(`  ✗ fetchNativeBalance failed: ${e}`);
+    console.error(`  (Is the RPC running at ${RPC_URL}?)`);
+    return;
+  }
+
+  // Test fetchNonce
+  try {
+    const nonce = await fetchNonce(RPC_URL, "0x0000000000000000000000000000000000000000");
+    assert(typeof nonce === "number", `fetchNonce returns number (${nonce})`);
+  } catch (e) {
+    failed++;
+    console.error(`  ✗ fetchNonce failed: ${e}`);
+  }
+}
+
+async function testConductorEncoding(): Promise<void> {
+  console.log("\n--- Conductor Calldata Encoding ---");
+
+  // Test encodeSwap produces valid hex
+  const swapCalldata = Conductor.encodeSwap({
+    tokenIn: "0x1111111111111111111111111111111111111111",
+    tokenOut: "0x2222222222222222222222222222222222222222",
+    fee: 3000,
+    amountIn: 1000000000000000000n,
+    minAmountOut: 900000000000000000n,
+  });
+  assert(swapCalldata.startsWith("0x"), "encodeSwap returns 0x-prefixed hex");
+  assert(swapCalldata.startsWith("0x" + "fb408d07"), "encodeSwap starts with correct selector");
+  assert(swapCalldata.length === 2 + 8 + 64 * 6, `encodeSwap has correct length (${swapCalldata.length})`);
+
+  // Test encodeSwapBTC
+  const btcCalldata = Conductor.encodeSwapBTC({
+    tokenOut: "0x2222222222222222222222222222222222222222",
+    fee: 3000,
+    minAmountOut: 900000000000000000n,
+  });
+  assert(btcCalldata.startsWith("0x" + "ad78c51c"), "encodeSwapBTC starts with correct selector");
+  assert(btcCalldata.length === 2 + 8 + 64 * 4, `encodeSwapBTC has correct length (${btcCalldata.length})`);
+
+  // Test integrator field
+  const withIntegrator = Conductor.encodeSwap({
+    tokenIn: "0x1111111111111111111111111111111111111111",
+    tokenOut: "0x2222222222222222222222222222222222222222",
+    fee: 3000,
+    amountIn: 100n,
+    minAmountOut: 90n,
+    integrator: "0x3333333333333333333333333333333333333333",
+  });
+  assert(
+    withIntegrator.includes("3333333333333333333333333333333333333333"),
+    "encodeSwap includes integrator address"
+  );
+}
+
+async function testPriceMath(): Promise<void> {
+  console.log("\n--- Price Math ---");
+
+  // Test priceToSqrtPriceX96 round-trip
+  const sqrtPrice = priceToSqrtPriceX96(1.0, 18, 18);
+  assert(sqrtPrice > 0n, `priceToSqrtPriceX96(1.0, 18, 18) = ${sqrtPrice}`);
+
+  const priceBack = sqrtPriceX96ToPrice(sqrtPrice, 18, 18);
+  assert(Math.abs(priceBack - 1.0) < 0.01, `sqrtPriceX96ToPrice round-trips to ~1.0 (got ${priceBack})`);
+
+  // Test with different decimals
+  const btcUsdb = priceToSqrtPriceX96(80000, 8, 18);
+  assert(btcUsdb > 0n, `priceToSqrtPriceX96(80000, 8, 18) = ${btcUsdb}`);
+
+  // Test fullRangeTicks
+  const ticks60 = fullRangeTicks(60);
+  assert(ticks60.tickLower % 60 === 0, `fullRangeTicks(60) lower aligned: ${ticks60.tickLower}`);
+  assert(ticks60.tickUpper % 60 === 0, `fullRangeTicks(60) upper aligned: ${ticks60.tickUpper}`);
+  assert(ticks60.tickLower < 0, "fullRangeTicks lower is negative");
+  assert(ticks60.tickUpper > 0, "fullRangeTicks upper is positive");
+
+  // Test sortTokens
+  const [t0, t1] = sortTokens(
+    "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+    "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+  );
+  assert(t0.toLowerCase() < t1.toLowerCase(), "sortTokens returns lower address first");
+
+  // Test FEE_TIERS
+  assert(FEE_TIERS.length === 3, `FEE_TIERS has 3 entries`);
+  assert(FEE_TIERS[0].fee === 500, "First fee tier is 500 (0.05%)");
+}
+
+async function testPoolHelpers(): Promise<void> {
+  console.log("\n--- Pool Helpers ---");
+
+  // These require a running localnet with Uniswap deployed.
+  // If RPC is not available, skip gracefully.
+  try {
+    const balance = await fetchNativeBalance(RPC_URL, "0x0000000000000000000000000000000000000000");
+    if (typeof balance !== "bigint") {
+      console.log("  (skipping pool tests — RPC not available)");
+      return;
+    }
+  } catch {
+    console.log("  (skipping pool tests — RPC not available)");
+    return;
+  }
+
+  // getPoolAddress with invalid factory should return null or throw
+  try {
+    const pool = await getPoolAddress(
+      RPC_URL,
+      "0x0000000000000000000000000000000000000001",
+      "0x1111111111111111111111111111111111111111",
+      "0x2222222222222222222222222222222222222222",
+      3000
+    );
+    // Either null (no pool) or a valid response is acceptable
+    assert(pool === null || typeof pool === "string", `getPoolAddress returns null or address (${pool})`);
+  } catch {
+    // eth_call to non-contract may throw — that's acceptable
+    passed++;
+    console.log("  ✓ getPoolAddress handles non-contract gracefully");
+  }
+}
+
+async function testInputValidation(): Promise<void> {
+  console.log("\n--- Input Validation ---");
+
+  // Test abiEncodeUint overflow protection
+  try {
+    Conductor.encodeSwap({
+      tokenIn: "0x1111111111111111111111111111111111111111",
+      tokenOut: "0x2222222222222222222222222222222222222222",
+      fee: 3000,
+      amountIn: -1n,
+      minAmountOut: 0n,
+    });
+    failed++;
+    console.error("  ✗ FAIL: encodeSwap should reject negative amountIn");
+  } catch {
+    passed++;
+    console.log("  ✓ encodeSwap rejects negative amountIn");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  console.log("=== Flashnet Execution SDK E2E Tests ===");
+  console.log(`Gateway: ${GATEWAY_URL}`);
+  console.log(`RPC:     ${RPC_URL}`);
+
+  // Tests that don't require a running localnet (pure logic)
+  await testConductorEncoding();
+  await testPriceMath();
+  await testInputValidation();
+
+  // Tests that require RPC
+  await testEvmReadHelpers();
+  await testPoolHelpers();
+
+  // Tests that require the full gateway
+  await testHealthCheck();
+  await testAuthentication();
+
+  console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`);
+
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((e) => {
+  console.error("Fatal error:", e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- New `ExecutionClient` class for interacting with the flashnet-execution gateway
- Supports multi-deposit intents (deposit-only and deposit-and-execute)
- Clean separation from the legacy AMM client (`FlashnetClient`) which talks to flashnet-services
- Canonical intent message signing that matches the Rust gateway's verification exactly

Closes flashnetxyz/flashnet-execution#125

## What changed

- **`src/execution/types.ts`** — Execution-specific types: `Deposit`, `DepositAsset`, `ExecuteIntentParams`, `DepositIntentParams`, `ExecuteResponse`, `ExecutionSigner`, `CanonicalIntentMessage`, etc.
- **`src/execution/client.ts`** — `ExecutionClient` class with:
  - `authenticate()` — challenge-response JWT auth with the execution gateway
  - `submitDeposit()` — deposit-only intents (credit recipient)
  - `submitExecute()` — deposit-and-execute intents (atomic deposit + EVM tx)
  - `health()` — gateway health check
  - Built-in keccak256 for `signedTxHash` computation (zero new dependencies)
  - Input validation matching the gateway's validation rules
- **`src/execution/index.ts`** — Module re-exports
- **`index.ts`** — Added execution module exports to main entry
- **`package.json`** — Added `./execution` modular export path
- **`.gitignore`** — Added `.claude/` directory

## Architecture

```
@flashnet/sdk
├── FlashnetClient (legacy — talks to flashnet-services/settlement)
├── ExecutionClient (new — talks to flashnet-execution gateway)
│   ├── authenticate() → challenge-response JWT
│   ├── submitDeposit({chainId, deposits[], recipient})
│   └── submitExecute({chainId, deposits[], signedTx})
└── shared utils (auth, spark-address, etc.)
```

The `ExecutionSigner` interface is pluggable — accepts Spark wallets or custom signers.

## Canonical intent message format

The SDK constructs the exact JSON the gateway reconstructs for signature verification:

```json
{
  "chainId": 1337,
  "transfers": [
    {"transferId": "aabb...", "amountSats": 100000, "assetType": "NativeSats"},
    {"transferId": "ccdd...", "amountSats": 500, "assetType": "BridgedToken", "tokenId": "0xee..."}
  ],
  "action": {"type": "deposit", "recipient": "0x..."} | {"type": "execute", "signedTxHash": "0x..."},
  "nonce": "uuid"
}
```

## How to test

```typescript
import { ExecutionClient } from "@flashnet/sdk/execution";
// or: import { ExecutionClient } from "@flashnet/sdk";

const client = new ExecutionClient(
  { gatewayUrl: "http://localhost:8080" },
  mySigner
);

await client.authenticate();

// Deposit-only
await client.submitDeposit({
  chainId: 1337,
  deposits: [{ sparkTransferId: "aabb...", amount: 100000, asset: { type: "btc" } }],
  recipient: "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD18",
});

// Deposit-and-execute (multi-deposit)
await client.submitExecute({
  chainId: 1337,
  deposits: [
    { sparkTransferId: btcId, amount: 50000, asset: { type: "btc" } },
    { sparkTransferId: tokenId, amount: 1000, asset: { type: "token", tokenId: "0x..." } },
  ],
  signedTx: "0xf86c...",
});
```

## Scope boundary

- This PR adds the execution client only. It does NOT modify the legacy `FlashnetClient`.
- The localnet UI will be updated in a follow-up to consume this SDK module.
- Swap support is not included (DEX-03, assigned to Jesse).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add ExecutionClient and execution-layer SDK for multi-deposit intents
> - Adds [`ExecutionClient`](https://github.com/flashnetxyz/ts-sdk/pull/58/files#diff-aa839a246a243d62eae2a42349f66de061dd3599fa0c873c35be53877bd6ec64) with challenge-response auth, `submitDeposit()` for deposit-only intents, and `submitExecute()` for deposit-and-execute intents, including a self-contained keccak-256 implementation for tx hash computation.
> - Adds [`Conductor`](https://github.com/flashnetxyz/ts-sdk/pull/58/files#diff-efbdcc600895c320db00ce64c08188d9bd86b72a56467938f0cb1686a3ae7d77) helpers for encoding swap, swapBTC, and approve calldata, plus high-level `swap()`, `swapBTC()`, and `swapWithApproval()` flows that sign and submit intents.
> - Adds zero-dependency EVM read helpers in [`src/execution/evm.ts`](https://github.com/flashnetxyz/ts-sdk/pull/58/files#diff-3b008adde7d8000fcda8de5b6e78616a4f3c33774c086334c93d8c34ac66508a) for token info, balances, allowances, and nonces via raw JSON-RPC.
> - Adds pool utilities in [`src/execution/pool.ts`](https://github.com/flashnetxyz/ts-sdk/pull/58/files#diff-51961ade81e26253ab217c9929c27eee586b3e7d3c3002321a36b343fd2b5b97) and [`src/execution/price-math.ts`](https://github.com/flashnetxyz/ts-sdk/pull/58/files#diff-181651aacece3685d62abe031ef9cb66341665eddafad7f932a3f2353f9f4fd7) for pool discovery, slot0 introspection, price/sqrtPriceX96 conversion, and full-range tick computation.
> - Exports the full execution-layer surface via the package root and a new `@flashnet/sdk/execution` subpath export.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #58 opened
>
> - Changed ABI encoding for `createBTCPool` function to remove dynamic tuple offset words and inline both tuples directly in calldata, and modified `abiEncodeBytes32` to left-pad bytes32 values with zeros instead of right-padding [58611a4]
> - Added validation in `ExecutionClient.submitIntent` method to throw an error when deposit amount exceeds safe integer range [58611a4]
> - Fixed `decodeUint` utility to handle empty hex strings after zero-stripping by adjusting BigInt construction [58611a4]
> - Added numeric validation to reject NaN and non-finite values in `validateDeposits` function and added range and integer validation to `abiEncodeUint8` function [911222c]
> - Updated health check test assertion to verify `health` method returns true [911222c]
> - Implemented Multicall3-based contract call batching infrastructure [b01c92c]
> - Refactored ERC-20 token metadata fetching to use Multicall3 batching [b01c92c]
> - Added high-level withdrawal operations `withdrawSats` and `withdrawToken` that encode calldata, fetch sender address and nonce, sign EIP-1559 transactions to the bridge contract with zero gas fees, submit via `client.submitExecute`, and return `WithdrawResult` containing submission identifiers and status [073af61]
> - Implemented bridge token address query functions `queryBridgedTokenAddress` and `waitForBridgedTokenAddress` that call `SparkBridge.tokenBySparkId(bytes32)` to retrieve the bridged EVM token address for a given Spark token ID [073af61]
> - Created zero-dependency ABI encoding functions `encodeWithdrawSats` and `encodeWithdrawToken` that compose 4-byte function selectors with ABI-encoded parameters including dynamic bytes arrays with offset, length, and right-padded data [073af61]
> - Added ABI encoding utility functions `padAddress`, `padUint256`, and `padBytes32` that strip `0x` prefixes, convert values to hex, and left-pad to 32 bytes (64 hex characters) for contract call parameters [073af61]
> - Implemented `ethCall` raw JSON-RPC helper function that performs `eth_call` requests to a provided RPC URL with target address and calldata, maintaining an incrementing request ID counter and parsing results or throwing on errors [073af61]
> - Defined three 4-byte function selector constants for `SparkBridge` methods: `withdrawSats(bytes)`, `withdrawBtkn(address,uint256,bytes)`, and `tokenBySparkId(bytes32)` [073af61]
> - Introduced TypeScript interfaces `BridgeConfig` and `WithdrawResult` describing bridge operation parameters and return values [073af61]
> - Exported bridge-related functions and types from the execution module index including `encodeWithdrawSats`, `encodeWithdrawToken`, `queryBridgedTokenAddress`, `waitForBridgedTokenAddress`, `withdrawSats`, `withdrawToken`, `BridgeConfig`, and `WithdrawResult` [073af61]
> - Migrated all blockchain interaction logic from custom JSON-RPC calls and manual ABI encoding/decoding to `viem` library functions [7e4e67a]
> - Added ABI definition modules for Conductor, Conductor Pool Creation, ERC20, Spark Bridge, and Uniswap V3 contracts [7e4e67a]
> - Added `viem` package version ^2.47.6 as a runtime dependency [7e4e67a]
> - Removed section divider comments and headings from execution module files [533353a]
> - Added re-exports for token approval, swap, and bridge withdrawal functions [f3988f9]
> - Added re-exports for bridge configuration and withdrawal result types [f3988f9]
> - Created shared `PublicClient` factory `getClient` in `src/execution/rpc.ts` with chain definition and Multicall3 support [b2d9ff8]
> - Replaced local `PublicClient` creation with shared `getClient` factory in bridge, evm, and pool modules [b2d9ff8]
> - Added `WEI_PER_SAT` constant and updated `withdrawSats` function in the execution bridge to convert satoshi amounts to wei [5780e0c]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee0e110.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->