### PR TITLE
ci(publish): restore pinned npm upgrade for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,11 +28,14 @@ jobs:
           node-version: 22.20.0
           registry-url: https://registry.npmjs.org
 
-      # Node 22.20 ships npm 10.9.x, which already supports OIDC trusted
-      # publishing. No self-upgrade needed. If a future npm feature
-      # requires a newer version, pin it explicitly (e.g. `npm@11.5`)
-      # rather than tracking @latest, to avoid inheriting runner-image
-      # regressions.
+      # Node 22.20 bundles npm 10.9.x, which signs provenance but does
+      # NOT implement the OIDC token-exchange endpoint used by npm's
+      # trusted publisher flow. Without this upgrade the publish step
+      # silently falls through to an unauthenticated PUT and the
+      # registry responds with a misleading 404. Pin the major so we
+      # do not inherit runner-image regressions the way `@latest` did.
+      - name: Upgrade npm for trusted publishing OIDC support
+        run: npm install -g npm@11
 
       - run: bun install
       - run: bun run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,10 +32,14 @@ jobs:
       # NOT implement the OIDC token-exchange endpoint used by npm's
       # trusted publisher flow. Without this upgrade the publish step
       # silently falls through to an unauthenticated PUT and the
-      # registry responds with a misleading 404. Pin the major so we
-      # do not inherit runner-image regressions the way `@latest` did.
+      # registry responds with a misleading 404. Pin the minor so the
+      # runner is fully reproducible and we do not inherit regressions
+      # from a future npm 11 minor the way `@latest` exposed us before.
+      # Bump the pin deliberately when a newer OIDC-capable minor is
+      # needed; 11.5 is the first line with the trusted-publisher
+      # token-exchange client.
       - name: Upgrade npm for trusted publishing OIDC support
-        run: npm install -g npm@11
+        run: npm install -g npm@11.5
 
       - run: bun install
       - run: bun run build


### PR DESCRIPTION
## Summary
- Node 22.20 bundles npm 10.9.x, which supports provenance signing but does not implement the OIDC token-exchange endpoint for npm's trusted publisher flow.
- After commit 389cb97 removed the `npm install -g npm@latest` step, publishes to main silently fell through to an unauthenticated PUT and the registry rejected it with a misleading 404 (`'@flashnet/sdk@0.5.8' is not in this registry`), despite the package existing.
- Restore the upgrade step, pinned to `npm@11` rather than `@latest`, so we do not re-inherit the runner-image regression that caused the original breakage on Node 22.22.2.

## Why the 404 was misleading
The publish log shows the provenance statement was signed and submitted to sigstore successfully (that uses the GitHub OIDC token directly), and only then the PUT to `registry.npmjs.org` came back 404. That asymmetry is the signature of an OIDC-authorization failure at the npm registry rather than a missing package.

## Test plan
- [ ] Merge and confirm the `Publish to npm` workflow succeeds on main
- [ ] `@flashnet/sdk@0.5.8` appears on npm with provenance attached

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore pinned `npm@11.5` upgrade step for OIDC trusted publishing in publish workflow
> Re-adds a dedicated 'Upgrade npm for trusted publishing OIDC support' step that runs `npm install -g npm@11.5` before publishing, required for OIDC provenance signing to work correctly. Risk: the `run` directive was removed from the 'Publish to npm' step in [publish.yml](.github/workflows/publish.yml), meaning that step currently has no command — this may be a partial/incomplete change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 624be29.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->