### PR TITLE
feat(execution): support attached deposit proofs on intents

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     }
   },
   "dependencies": {
+    "@noble/hashes": "^1.7.0",
     "bech32": "^2.0.0",
     "fast-sha256": "1.3.0",
     "light-bolt11-decoder": "^3.2.0",

--- a/src/execution/client.ts
+++ b/src/execution/client.ts
@@ -37,9 +37,12 @@ import type { LocalAccount } from "viem/accounts";
 import { encodeWithdrawSats, encodeWithdrawToken } from "./gateway";
 import { fetchNonce, fetchEip1559Fees } from "./evm";
 import {
-  generateProofNonce,
+  PLACEHOLDER_DEPOSIT_PROOF,
+  canonicalIntentId,
+  depositAssetToWire,
   isTerminalIntentStatus,
   resolveExpiresAt,
+  u256Hex,
 } from "./types";
 import type {
   CanonicalIntentAction,
@@ -170,13 +173,6 @@ export interface DepositParams extends IntentExpiry, ProofOptOut {
   deposits: Deposit[];
   /** EVM address to credit. If omitted, credits the identity key's EVM address. */
   recipient?: string;
-  /**
-   * Optional explicit nonce (32 lowercase hex chars, no `0x`). When
-   * omitted the SDK generates one with {@link generateProofNonce}.
-   * Provide this only when the caller already holds matching
-   * `depositProof` values that were minted under a specific nonce.
-   */
-  nonce?: string;
 }
 
 /**
@@ -184,15 +180,15 @@ export interface DepositParams extends IntentExpiry, ProofOptOut {
  *
  * This is the modular escape hatch - most callers should let
  * `deposit` / `execute` handle proof fetching automatically.
+ *
+ * `intentId` is the canonical BLAKE3 hash of the intent the caller is
+ * about to submit. Compute it via {@link canonicalIntentId} from the
+ * exact canonical transfers + action you intend to sign — the gateway
+ * binds the returned proofs to this value and a mismatch on `/execute`
+ * is a hard rejection.
  */
 export interface VerifyDepositParams {
-  /**
-   * 16-byte nonce as 32 lowercase hex chars (no `0x`). Use
-   * {@link generateProofNonce} to generate one, then keep it for the
-   * subsequent `/execute` call. UUID-shaped nonces are not accepted on
-   * this endpoint.
-   */
-  nonce: string;
+  intentId: string;
   /**
    * Spark transfer ids to verify. Accepts dashed UUID, plain hex, or
    * `0x`-prefixed hex; the gateway canonicalises before lookup.
@@ -242,13 +238,6 @@ export interface ExecuteParams extends IntentExpiry, ProofOptOut {
   deposits?: Deposit[];
   /** Hex-encoded signed EVM transaction (RLP-serialized, 0x-prefixed). */
   signedTx: string;
-  /**
-   * Optional explicit nonce (32 lowercase hex chars, no `0x`). When
-   * omitted the SDK generates one. Provide this only when the caller
-   * already holds matching `depositProof` values that were minted
-   * under a specific nonce.
-   */
-  nonce?: string;
 }
 
 /**
@@ -400,8 +389,8 @@ export class ExecutionClient {
    * into the request the gateway receives. Pass `params.manualProofs:
    * true` to take over the proof flow (e.g., to inspect rejections,
    * cache proofs, or submit unproven), or pre-populate
-   * `deposits[i].depositProof` and `params.nonce` if proofs were
-   * fetched out of band.
+   * `deposits[i].depositProof` if proofs were fetched out of band
+   * against the same canonical intent.
    *
    * If the gateway has not enabled proof verification yet (returns
    * 503) the call falls back to the legacy proofless path. Any
@@ -414,16 +403,17 @@ export class ExecutionClient {
     validateDeposits(params.deposits);
 
     const recipient = params.recipient ?? (await this.getEvmAddress());
+    const recipientLower = recipient.toLowerCase();
 
     const action: CanonicalIntentAction = {
       type: "deposit",
-      recipient: recipient.toLowerCase(),
+      recipient: recipientLower,
     };
 
     return this.submitIntent(params.deposits, action, {
-      recipient: recipient.toLowerCase(),
+      recipient: recipientLower,
+      recipientForHash: recipientLower,
       expiresAt: params.expiresAt,
-      nonce: params.nonce,
       manualProofs: params.manualProofs,
     });
   }
@@ -446,14 +436,14 @@ export class ExecutionClient {
     params: VerifyDepositParams
   ): Promise<VerifyDepositsResponse> {
     this.requireAuth();
-    if (!params.nonce || params.nonce.trim() === "") {
-      throw new Error("nonce is required");
+    if (!params.intentId || params.intentId.trim() === "") {
+      throw new Error("intentId is required");
     }
     if (!Array.isArray(params.sparkTransferIds) || params.sparkTransferIds.length === 0) {
       throw new Error("sparkTransferIds must contain at least one entry");
     }
     const body: VerifyDepositsRequest = {
-      nonce: params.nonce,
+      intentId: params.intentId,
       transfers: params.sparkTransferIds.map((sparkTransferId) => ({
         sparkTransferId,
       })),
@@ -466,28 +456,24 @@ export class ExecutionClient {
   /**
    * Auto-attach proofs for any deposit that arrives without one.
    *
-   * Returns the (possibly mutated) deposit list plus the nonce that
-   * was used. The nonce contract is strict:
+   * Returns the (possibly mutated) deposit list. Pre-attached proofs
+   * are kept as-is; the caller is responsible for ensuring they were
+   * minted against the same canonical intent (same `intentId`). The
+   * gateway will reject mismatched bindings on `/execute`.
    *
-   * - Any pre-attached `depositProof` must have been minted under a
-   *   specific nonce. The caller MUST supply that nonce as
-   *   `explicitNonce`; otherwise we throw before signing rather than
-   *   let the gateway reject the intent for a binding mismatch.
-   * - When no proofs are pre-attached and we have to fetch them, we
-   *   either honour `explicitNonce` or generate a fresh value via
-   *   `generateProofNonce()`.
-   *
-   * On 503 from the gateway (proof verification not yet enabled), the
-   * call returns the inputs unchanged so the intent can be submitted
-   * on the legacy path. Any other failure - including a non-empty
-   * `rejections[]` - throws to surface the issue before the intent
-   * is signed.
+   * On 503 from the gateway (proof verification not yet enabled), each
+   * deposit without a pre-attached proof receives the placeholder
+   * shape so the canonical preimage still includes a `depositProof`
+   * field. The gateway's `has_valid_shape()` check treats placeholders
+   * as "not configured" and falls through to the legacy polling
+   * admission. Any other failure - including a non-empty `rejections[]`
+   * - throws to surface the issue before the intent is signed.
    */
   private async resolveProofs(
     deposits: Deposit[],
-    explicitNonce: string | undefined,
+    intentId: string,
     manualProofs: boolean | undefined
-  ): Promise<{ deposits: Deposit[]; nonce: string | undefined }> {
+  ): Promise<Deposit[]> {
     // Validate the shape of any pre-attached proof so a malformed
     // `depositProof` (wrong-length signature, etc.) fails here with a
     // clear message rather than being rejected by the gateway after
@@ -507,41 +493,25 @@ export class ExecutionClient {
       }
     }
 
-    const hasPreAttached = deposits.some((d) => Boolean(d.depositProof));
-
-    // Pre-attached proofs are bound to a specific nonce the caller
-    // chose when fetching them. We cannot reconstruct that nonce from
-    // the opaque payload bytes, so the caller must thread it through
-    // explicitly. Catching this here avoids a confusing
-    // `ProofBindingMismatch` rejection at submit time.
-    if (hasPreAttached && (!explicitNonce || explicitNonce.trim() === "")) {
-      throw new Error(
-        "deposits include pre-attached depositProof entries but no nonce was supplied. " +
-          "Pass the same nonce that was used when fetching the proofs (e.g. via verifyDeposit)."
-      );
-    }
-
     // Manual mode (BYO proofs): pass the caller's list through
-    // verbatim. They're responsible for any verification and for
-    // wiring up the nonce.
+    // verbatim. They're responsible for any verification.
     if (manualProofs || deposits.length === 0) {
-      return { deposits, nonce: explicitNonce };
+      return deposits;
     }
 
     // All deposits already have a proof - nothing to fetch.
     if (deposits.every((d) => Boolean(d.depositProof))) {
-      return { deposits, nonce: explicitNonce };
+      return deposits;
     }
 
     const missing = deposits
       .map((d, i) => (d.depositProof ? -1 : i))
       .filter((i) => i >= 0);
 
-    const nonce = explicitNonce ?? generateProofNonce();
     let response: VerifyDepositsResponse;
     try {
       response = await this.verifyDeposit({
-        nonce,
+        intentId,
         sparkTransferIds: missing.map((i) => deposits[i]!.sparkTransferId),
       });
     } catch (err) {
@@ -549,9 +519,9 @@ export class ExecutionClient {
       // /verifyDeposit it returns 503. Fall through to the legacy
       // proofless path instead of failing the caller's intent. Any
       // pre-attached proofs flow through unchanged - the legacy path
-      // ignores `depositProof`.
+      // ignores the placeholder shape via `has_valid_shape()`.
       if (isGatewayUnavailable(err)) {
-        return { deposits, nonce: explicitNonce };
+        return deposits;
       }
       throw err;
     }
@@ -588,7 +558,7 @@ export class ExecutionClient {
       }
       out[originalIndex] = { ...out[originalIndex]!, depositProof: proof };
     }
-    return { deposits: out, nonce };
+    return out;
   }
 
   /**
@@ -619,6 +589,7 @@ export class ExecutionClient {
 
     return this.submitIntent([], { type: "execute", signedTxHash: viemKeccak256(signedTx) }, {
       evmTransaction: signedTx,
+      recipientForHash: account.address,
       expiresAt: params.expiresAt,
     });
   }
@@ -653,6 +624,7 @@ export class ExecutionClient {
 
     return this.submitIntent([], { type: "execute", signedTxHash: viemKeccak256(signedTx) }, {
       evmTransaction: signedTx,
+      recipientForHash: account.address,
       expiresAt: params.expiresAt,
     });
   }
@@ -677,6 +649,11 @@ export class ExecutionClient {
       : `0x${params.signedTx}`;
     const txHash = viemKeccak256(txHex as `0x${string}`);
 
+    // The canonical recipient for the BLAKE3 intent_id is the recovered
+    // signer of the signed tx. For self-signed flows (the SDK signs with
+    // its own identity key) that is the SDK's own EVM address.
+    const account = await this.getEvmAccount();
+
     // Pass the normalized txHex to the gateway, not the raw input. If the
     // server recomputes the hash from evmTransaction (it does, for
     // signature verification) the hashes must match — passing the
@@ -687,8 +664,8 @@ export class ExecutionClient {
       { type: "execute", signedTxHash: txHash },
       {
         evmTransaction: txHex,
+        recipientForHash: account.address,
         expiresAt: params.expiresAt,
-        nonce: params.nonce,
         manualProofs: params.manualProofs,
       }
     );
@@ -854,52 +831,66 @@ export class ExecutionClient {
     requestAction: {
       recipient?: string;
       evmTransaction?: string;
+      /**
+       * Canonical recipient used in the BLAKE3 intent-id preimage. For
+       * Deposit it equals `requestAction.recipient`; for Execute it is
+       * the recovered ECDSA signer of `evmTransaction` (for self-signed
+       * flows that is the SDK's own EVM address). Ignored for Clawback.
+       */
+      recipientForHash: string;
       expiresAt?: number;
-      nonce?: string;
       manualProofs?: boolean;
     }
   ): Promise<ExecuteResponse> {
-    // Auto-attach proofs for any deposit that arrives without one.
-    // Falls through silently on a 503 from /verifyDeposit (soft-mode
-    // gateway), and throws on any per-transfer rejection.
-    const { deposits, nonce: resolvedNonce } = await this.resolveProofs(
+    const expiresAt = resolveExpiresAt(requestAction.expiresAt);
+
+    // Build wire-shaped transfers (no proofs yet). The intent_id BLAKE3
+    // preimage does NOT cover `depositProof` or `expiresAt`, so we can
+    // compute the canonical intent id from a proof-less projection and
+    // attach proofs afterwards. See `canonicalIntentId` in ./types.
+    const placeholderTransfers: CanonicalTransferEntry[] = rawDeposits.map((d) => {
+      const amountBig =
+        typeof d.amount === "bigint" ? d.amount : BigInt(d.amount);
+      if (amountBig < 0n) {
+        throw new Error(`deposits[${d.sparkTransferId}].amount must be non-negative`);
+      }
+      return {
+        transferId: d.sparkTransferId,
+        amount: u256Hex(amountBig),
+        asset: depositAssetToWire(d.asset),
+        depositProof: d.depositProof ?? PLACEHOLDER_DEPOSIT_PROOF,
+      };
+    });
+
+    const intentId = canonicalIntentId({
+      chainId: this.config.chainId,
+      transfers: placeholderTransfers,
+      action,
+      recipientForHash: requestAction.recipientForHash,
+      signedTxHex: requestAction.evmTransaction,
+    });
+
+    // Auto-attach proofs for any deposit that arrives without one. The
+    // returned `Deposit[]` is the same caller-facing shape with
+    // `depositProof` populated. Falls through silently on a 503 from
+    // /verifyDeposit (soft-mode gateway), and throws on any
+    // per-transfer rejection.
+    const deposits = await this.resolveProofs(
       rawDeposits,
-      requestAction.nonce,
+      intentId,
       requestAction.manualProofs
     );
 
-    // Default to the 16-byte hex format. UUIDs are still accepted by the
-    // gateway on the proofless legacy path, but the proof flow requires
-    // 32 lowercase hex chars - using the proof-compatible shape for all
-    // new intents lets the same nonce flow into `/verifyDeposit` when
-    // proofs are added.
-    const nonce = resolvedNonce ?? generateProofNonce();
-    const expiresAt = resolveExpiresAt(requestAction.expiresAt);
-
+    // Final canonical transfers with resolved proofs (or placeholders).
     const transfers: CanonicalTransferEntry[] = deposits.map((d) => {
-      // Preserve full u64 precision by carrying bigint all the way to the
-      // canonical JSON. Number() casting would lose precision for any
-      // 18-decimal token amount (1e18 > 2^53). We validate the amount fits
-      // in u64 here; the custom serializer below emits bigints as JSON
-      // numeric literals (which Rust's serde_json parses to u64).
       const amountBig =
         typeof d.amount === "bigint" ? d.amount : BigInt(d.amount);
-      if (amountBig < 0n || amountBig > U64_MAX) {
-        throw new Error(
-          `deposit amount ${d.amount} out of u64 range [0, ${U64_MAX}]`
-        );
-      }
-      const entry: CanonicalTransferEntry = {
+      return {
         transferId: d.sparkTransferId,
-        // Store as bigint so the custom serializer emits it as a numeric
-        // literal preserving full precision.
-        amountSats: amountBig,
-        assetType: d.asset.type === "btc" ? "NativeSats" : "SparkToken",
+        amount: u256Hex(amountBig),
+        asset: depositAssetToWire(d.asset),
+        depositProof: d.depositProof ?? PLACEHOLDER_DEPOSIT_PROOF,
       };
-      if (d.asset.type === "token") {
-        entry.tokenId = d.asset.tokenId;
-      }
-      return entry;
     });
 
     // IMPORTANT: Field order here MUST match the declaration order of
@@ -913,35 +904,29 @@ export class ExecutionClient {
       chainId: this.config.chainId,
       transfers,
       action,
-      nonce,
       expiresAt,
     };
 
     const messageJson = stringifyWithBigint(canonicalMessage);
     const signature = await this.signer.signMessage(messageJson);
 
-    // Body mirrors the Rust `ExecuteRequest` struct. `amount` is u64 on
-    // the Rust side; we emit bigints as numeric literals (not strings)
-    // so serde_json parses them as u64 without any serde override.
+    // Body mirrors the Rust `ExecuteRequest` struct. `amount` is U256
+    // hex on the Rust side; we emit `0x`-prefixed lowercase hex
+    // matching alloy's serde shape.
     //
-    // Each deposit may optionally carry a `depositProof` populated by
-    // an earlier `/verifyDeposit` call. The gateway re-verifies attached
-    // proofs in line; missing proofs fall through to the legacy path.
+    // Each deposit carries a `depositProof` (either the gateway-signed
+    // value from /verifyDeposit, a caller-supplied pre-attached proof,
+    // or the {payloadBytes:"0x", signature:"0x"} placeholder that the
+    // gateway treats as "not configured" via has_valid_shape()).
     const body: Record<string, unknown> = {
       chainId: this.config.chainId,
-      deposits: deposits.map((d) => {
-        const entry: Record<string, unknown> = {
-          sparkTransferId: d.sparkTransferId,
-          asset: d.asset,
-          amount: d.amount,
-        };
-        if (d.depositProof) {
-          entry.depositProof = d.depositProof;
-        }
-        return entry;
-      }),
+      deposits: transfers.map((t) => ({
+        sparkTransferId: t.transferId,
+        amount: t.amount,
+        asset: t.asset,
+        depositProof: t.depositProof,
+      })),
       signature,
-      nonce,
       expiresAt,
     };
 

--- a/src/execution/client.ts
+++ b/src/execution/client.ts
@@ -29,7 +29,13 @@
  * ```
  */
 
-import { createPublicClient, http, keccak256 as viemKeccak256, type PublicClient } from "viem";
+import {
+  createPublicClient,
+  http,
+  keccak256 as viemKeccak256,
+  recoverTransactionAddress,
+  type PublicClient,
+} from "viem";
 import { sha256 } from "@noble/hashes/sha2";
 import { bytesToHex } from "@noble/curves/abstract/utils";
 import { sparkWalletToEvmAccount, getWalletSigner, type SparkWalletInput } from "./spark-evm-account";
@@ -673,10 +679,17 @@ export class ExecutionClient {
       : `0x${params.signedTx}`;
     const txHash = viemKeccak256(txHex as `0x${string}`);
 
-    // The canonical recipient for the BLAKE3 intent_id is the recovered
-    // signer of the signed tx. For self-signed flows (the SDK signs with
-    // its own identity key) that is the SDK's own EVM address.
-    const account = await this.getEvmAccount();
+    // The canonical recipient for the BLAKE3 intent_id is the RECOVERED
+    // signer of the signed tx — that's exactly what the gateway uses
+    // (`recover_sender_from_signed_tx`). `execute()` accepts arbitrary
+    // externally-signed transactions, so we must not assume the SDK's own
+    // identity account signed it; recovering keeps the intent_id (and any
+    // attached deposit-proof binding) in lockstep with the gateway.
+    // Flashnet withdraw/execute txs are EIP-1559 (0x02-typed); the cast
+    // satisfies viem's serialized-transaction union.
+    const recipientForHash = await recoverTransactionAddress({
+      serializedTransaction: txHex as `0x02${string}`,
+    });
 
     // Pass the normalized txHex to the gateway, not the raw input. If the
     // server recomputes the hash from evmTransaction (it does, for
@@ -688,7 +701,7 @@ export class ExecutionClient {
       { type: "execute", signedTxHash: txHash },
       {
         evmTransaction: txHex,
-        recipientForHash: account.address,
+        recipientForHash,
         expiresAt: params.expiresAt,
         manualProofs: params.manualProofs,
       }

--- a/src/execution/client.ts
+++ b/src/execution/client.ts
@@ -49,7 +49,6 @@ import type {
   DepositRejection,
   ExecuteResponse,
   ExecutionSigner,
-  IndexedDepositProof,
   IntentStatus,
   IntentStatusResponse,
   NetworkInfo,
@@ -492,16 +491,17 @@ export class ExecutionClient {
     // Validate the shape of any pre-attached proof so a malformed
     // `depositProof` (wrong-length signature, etc.) fails here with a
     // clear message rather than being rejected by the gateway after
-    // the intent is signed.
+    // the intent is signed. The gateway accepts both `0x`-prefixed
+    // and bare hex - so does this check.
     for (let i = 0; i < deposits.length; i++) {
       const proof = deposits[i]!.depositProof;
       if (proof) {
-        if (!proof.payloadBytes || typeof proof.payloadBytes !== "string") {
-          throw new Error(`deposits[${i}].depositProof.payloadBytes is missing or not a string`);
+        if (typeof proof.payloadBytes !== "string" || proof.payloadBytes.trim() === "") {
+          throw new Error(`deposits[${i}].depositProof.payloadBytes is missing or empty`);
         }
-        if (typeof proof.signature !== "string" || !/^[0-9a-fA-F]{128}$/.test(proof.signature)) {
+        if (typeof proof.signature !== "string" || !SIGNATURE_HEX_RE.test(proof.signature)) {
           throw new Error(
-            `deposits[${i}].depositProof.signature must be 64 hex bytes (128 chars)`
+            `deposits[${i}].depositProof.signature must be 64 hex bytes (128 chars, optional 0x prefix)`
           );
         }
       }
@@ -557,12 +557,14 @@ export class ExecutionClient {
     }
 
     if (response.rejections.length > 0) {
-      const summary = response.rejections
-        .map((r) => `[${missing[r.index] ?? r.index}] ${r.sparkTransferId}: ${r.reason} (${r.message})`)
-        .join("; ");
-      throw new Error(
-        `verifyDeposit returned ${response.rejections.length} rejection(s): ${summary}`
-      );
+      // Re-index rejections to the original deposit positions so
+      // callers can pair them with their `deposits[]` array by index
+      // without knowing about the internal `missing` projection.
+      const remapped: DepositRejection[] = response.rejections.map((r) => ({
+        ...r,
+        index: missing[r.index] ?? r.index,
+      }));
+      throw new VerifyDepositRejectedError(remapped);
     }
     if (response.proofs.length !== missing.length) {
       throw new Error(
@@ -571,7 +573,7 @@ export class ExecutionClient {
     }
 
     const proofByMissingIndex = new Map<number, SignedDepositProof>();
-    for (const p of response.proofs as IndexedDepositProof[]) {
+    for (const p of response.proofs) {
       proofByMissingIndex.set(p.index, p.proof);
     }
 
@@ -1049,6 +1051,28 @@ function isGatewayUnavailable(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   return /failed \(503\)/.test(err.message);
 }
+
+/**
+ * Thrown when `/verifyDeposit` returns per-transfer rejections. The
+ * `rejections` field carries the structured details so callers can
+ * branch programmatically on `reason` (e.g. retry on
+ * `transfer_not_found`, alert on `condition_a_failed`) instead of
+ * parsing the message string.
+ */
+export class VerifyDepositRejectedError extends Error {
+  readonly rejections: DepositRejection[];
+  constructor(rejections: DepositRejection[]) {
+    const summary = rejections
+      .map((r) => `[${r.index}] ${r.sparkTransferId}: ${r.reason} (${r.message})`)
+      .join("; ");
+    super(`verifyDeposit returned ${rejections.length} rejection(s): ${summary}`);
+    this.name = "VerifyDepositRejectedError";
+    this.rejections = rejections;
+  }
+}
+
+/** Hex-with-optional-0x of exactly 64 bytes (128 hex chars). */
+const SIGNATURE_HEX_RE = /^(0x|0X)?[0-9a-fA-F]{128}$/;
 
 function validateDeposits(deposits: Deposit[]): void {
   if (deposits.length === 0) {

--- a/src/execution/client.ts
+++ b/src/execution/client.ts
@@ -41,6 +41,7 @@ import {
   canonicalIntentId,
   depositAssetToWire,
   isTerminalIntentStatus,
+  normalizeIntentStatus,
   resolveExpiresAt,
   u256Hex,
 } from "./types";
@@ -694,11 +695,17 @@ export class ExecutionClient {
         `gateway ${path} returned HTTP ${resp.status}: ${text}`
       );
     }
+    let parsed: IntentStatusResponse;
     try {
-      return JSON.parse(text) as IntentStatusResponse;
+      parsed = JSON.parse(text) as IntentStatusResponse;
     } catch {
       throw new Error(`gateway ${path} response is not valid JSON: ${text}`);
     }
+    // Canonicalize to SCREAMING_SNAKE_CASE — the gateway is internally
+    // inconsistent (POST /execute emits lowercase "accepted", GET emits
+    // uppercase) and consumers compare against IntentStatus.
+    parsed.status = normalizeIntentStatus(parsed.status as unknown as string);
+    return parsed;
   }
 
   /**
@@ -937,9 +944,13 @@ export class ExecutionClient {
       body.evmTransaction = requestAction.evmTransaction;
     }
 
-    return this.post<ExecuteResponse>("/api/v1/execute", body, {
+    const resp = await this.post<ExecuteResponse>("/api/v1/execute", body, {
       Authorization: `Bearer ${this.accessToken}`,
     });
+    // POST /execute returns the initial status as lowercase "accepted";
+    // canonicalize so callers always see SCREAMING_SNAKE_CASE.
+    resp.status = normalizeIntentStatus(resp.status as unknown as string);
+    return resp;
   }
 
   private requireAuth(): void {

--- a/src/execution/client.ts
+++ b/src/execution/client.ts
@@ -146,15 +146,19 @@ export interface IntentExpiry {
 }
 
 /**
- * Mixin: opt out of the automatic proof-fetching step that
- * `deposit` / `execute` perform on any deposit that arrives without a
- * `depositProof`. Default is `false` (auto-fetch). Set `true` only
- * when the caller has a reason to skip the verification step entirely
- * (e.g. a benchmarking probe, or a flow where the gateway is known
- * not to expose `/verifyDeposit`).
+ * "Bring your own proofs" opt-out. When `true`, `deposit` / `execute`
+ * do not fetch any proofs themselves - the caller is responsible for
+ * the entire proof flow, either by pre-attaching `depositProof` to
+ * each entry of `deposits[]` (with a matching `nonce`) or by
+ * deliberately submitting an unproven intent.
+ *
+ * Default is `false`: the SDK auto-fetches proofs for any deposit
+ * that arrives without one. This is the recommended path - reach for
+ * `manualProofs: true` only when you need to drive the verification
+ * step yourself.
  */
 export interface ProofOptOut {
-  skipProofs?: boolean;
+  manualProofs?: boolean;
 }
 
 /** Parameters for a deposit intent. */
@@ -394,9 +398,11 @@ export class ExecutionClient {
    * identity key's EVM address. Any deposit that arrives without an
    * attached `depositProof` is automatically proof-bound first by an
    * internal `/verifyDeposit` call; the resulting proofs are stitched
-   * into the request the gateway receives. Pass `params.skipProofs:
-   * true` to opt out (rare), or pre-populate `deposits[i].depositProof`
-   * and `params.nonce` if proofs were fetched out of band.
+   * into the request the gateway receives. Pass `params.manualProofs:
+   * true` to take over the proof flow (e.g., to inspect rejections,
+   * cache proofs, or submit unproven), or pre-populate
+   * `deposits[i].depositProof` and `params.nonce` if proofs were
+   * fetched out of band.
    *
    * If the gateway has not enabled proof verification yet (returns
    * 503) the call falls back to the legacy proofless path. Any
@@ -419,7 +425,7 @@ export class ExecutionClient {
       recipient: recipient.toLowerCase(),
       expiresAt: params.expiresAt,
       nonce: params.nonce,
-      skipProofs: params.skipProofs,
+      manualProofs: params.manualProofs,
     });
   }
 
@@ -462,26 +468,68 @@ export class ExecutionClient {
    * Auto-attach proofs for any deposit that arrives without one.
    *
    * Returns the (possibly mutated) deposit list plus the nonce that
-   * was used. If the caller already passed a nonce we honour it; if
-   * not, and at least one verification call was needed, we generate
-   * a proof-compatible 16-byte hex value via `generateProofNonce()`.
+   * was used. The nonce contract is strict:
    *
-   * On 503 from the gateway (proof verification not yet enabled),
-   * the call returns the inputs unchanged so the intent can be
-   * submitted on the legacy path. Any other failure - including a
-   * non-empty `rejections[]` - throws to surface the issue before
-   * the intent is signed.
+   * - Any pre-attached `depositProof` must have been minted under a
+   *   specific nonce. The caller MUST supply that nonce as
+   *   `explicitNonce`; otherwise we throw before signing rather than
+   *   let the gateway reject the intent for a binding mismatch.
+   * - When no proofs are pre-attached and we have to fetch them, we
+   *   either honour `explicitNonce` or generate a fresh value via
+   *   `generateProofNonce()`.
+   *
+   * On 503 from the gateway (proof verification not yet enabled), the
+   * call returns the inputs unchanged so the intent can be submitted
+   * on the legacy path. Any other failure - including a non-empty
+   * `rejections[]` - throws to surface the issue before the intent
+   * is signed.
    */
   private async resolveProofs(
     deposits: Deposit[],
     explicitNonce: string | undefined,
-    skipProofs: boolean | undefined
+    manualProofs: boolean | undefined
   ): Promise<{ deposits: Deposit[]; nonce: string | undefined }> {
-    if (
-      skipProofs ||
-      deposits.length === 0 ||
-      deposits.every((d) => Boolean(d.depositProof))
-    ) {
+    // Validate the shape of any pre-attached proof so a malformed
+    // `depositProof` (wrong-length signature, etc.) fails here with a
+    // clear message rather than being rejected by the gateway after
+    // the intent is signed.
+    for (let i = 0; i < deposits.length; i++) {
+      const proof = deposits[i]!.depositProof;
+      if (proof) {
+        if (!proof.payloadBytes || typeof proof.payloadBytes !== "string") {
+          throw new Error(`deposits[${i}].depositProof.payloadBytes is missing or not a string`);
+        }
+        if (typeof proof.signature !== "string" || !/^[0-9a-fA-F]{128}$/.test(proof.signature)) {
+          throw new Error(
+            `deposits[${i}].depositProof.signature must be 64 hex bytes (128 chars)`
+          );
+        }
+      }
+    }
+
+    const hasPreAttached = deposits.some((d) => Boolean(d.depositProof));
+
+    // Pre-attached proofs are bound to a specific nonce the caller
+    // chose when fetching them. We cannot reconstruct that nonce from
+    // the opaque payload bytes, so the caller must thread it through
+    // explicitly. Catching this here avoids a confusing
+    // `ProofBindingMismatch` rejection at submit time.
+    if (hasPreAttached && (!explicitNonce || explicitNonce.trim() === "")) {
+      throw new Error(
+        "deposits include pre-attached depositProof entries but no nonce was supplied. " +
+          "Pass the same nonce that was used when fetching the proofs (e.g. via verifyDeposit)."
+      );
+    }
+
+    // Manual mode (BYO proofs): pass the caller's list through
+    // verbatim. They're responsible for any verification and for
+    // wiring up the nonce.
+    if (manualProofs || deposits.length === 0) {
+      return { deposits, nonce: explicitNonce };
+    }
+
+    // All deposits already have a proof - nothing to fetch.
+    if (deposits.every((d) => Boolean(d.depositProof))) {
       return { deposits, nonce: explicitNonce };
     }
 
@@ -499,7 +547,9 @@ export class ExecutionClient {
     } catch (err) {
       // Soft-mode fallback: if the gateway does not yet expose
       // /verifyDeposit it returns 503. Fall through to the legacy
-      // proofless path instead of failing the caller's intent.
+      // proofless path instead of failing the caller's intent. Any
+      // pre-attached proofs flow through unchanged - the legacy path
+      // ignores `depositProof`.
       if (isGatewayUnavailable(err)) {
         return { deposits, nonce: explicitNonce };
       }
@@ -611,7 +661,7 @@ export class ExecutionClient {
    *
    * When `params.deposits` is non-empty, the same automatic proof
    * attachment that `deposit()` does applies here. Set
-   * `params.skipProofs: true` to opt out.
+   * `params.manualProofs: true` to take over the proof flow yourself.
    */
   async execute(params: ExecuteParams): Promise<ExecuteResponse> {
     this.requireAuth();
@@ -637,7 +687,7 @@ export class ExecutionClient {
         evmTransaction: txHex,
         expiresAt: params.expiresAt,
         nonce: params.nonce,
-        skipProofs: params.skipProofs,
+        manualProofs: params.manualProofs,
       }
     );
   }
@@ -804,7 +854,7 @@ export class ExecutionClient {
       evmTransaction?: string;
       expiresAt?: number;
       nonce?: string;
-      skipProofs?: boolean;
+      manualProofs?: boolean;
     }
   ): Promise<ExecuteResponse> {
     // Auto-attach proofs for any deposit that arrives without one.
@@ -813,7 +863,7 @@ export class ExecutionClient {
     const { deposits, nonce: resolvedNonce } = await this.resolveProofs(
       rawDeposits,
       requestAction.nonce,
-      requestAction.skipProofs
+      requestAction.manualProofs
     );
 
     // Default to the 16-byte hex format. UUIDs are still accepted by the

--- a/src/execution/client.ts
+++ b/src/execution/client.ts
@@ -35,7 +35,7 @@ import { bytesToHex } from "@noble/curves/abstract/utils";
 import { sparkWalletToEvmAccount, getWalletSigner, type SparkWalletInput } from "./spark-evm-account";
 import type { LocalAccount } from "viem/accounts";
 import { encodeWithdrawSats, encodeWithdrawToken } from "./gateway";
-import { fetchNonce, fetchEip1559Fees } from "./evm";
+import { fetchNonce, fetchEip1559Fees, fetchNativeBalance } from "./evm";
 import {
   PLACEHOLDER_DEPOSIT_PROOF,
   canonicalIntentId,
@@ -571,6 +571,29 @@ export class ExecutionClient {
   async withdraw(params: WithdrawParams): Promise<ExecuteResponse> {
     this.requireAuth();
     const account = await this.getEvmAccount();
+
+    // Pre-flight balance guard. A native withdraw moves
+    // `amount * WEI_PER_SAT` wei; gas is zero on Flashnet. If the EVM
+    // balance can't cover the value, the sequencer drops the tx for
+    // "lack of funds" and the intent EXPIRES — but the gateway keeps the
+    // EXPIRED row under the `intent_id` UNIQUE constraint and the EVM
+    // nonce never advances (the tx was never included). The result is a
+    // permanent 409 ("intent_id already submitted") on every identical
+    // retry. Refuse here with a clear message so a withdraw submitted
+    // before its funding deposit has FINALIZED can be retried later
+    // instead of burning its intent_id. (Most common cause: withdrawing
+    // before the deposit credited the recipient.)
+    const value = params.amount * WEI_PER_SAT;
+    const balance = await fetchNativeBalance(this.config.rpcUrl, account.address);
+    if (balance < value) {
+      throw new Error(
+        `insufficient EVM balance for withdraw: have ${balance} wei ` +
+          `(${balance / WEI_PER_SAT} sats), need ${value} wei (${params.amount} sats). ` +
+          `If you just deposited, wait for the deposit intent to reach FINALIZED ` +
+          `(getIntentStatus / waitForIntent) before withdrawing.`
+      );
+    }
+
     const sparkRecipient = await this.getSparkRecipientHex();
     const calldata = encodeWithdrawSats(sparkRecipient);
     const nonce = await fetchNonce(this.config.rpcUrl, account.address);

--- a/src/execution/client.ts
+++ b/src/execution/client.ts
@@ -36,17 +36,26 @@ import { sparkWalletToEvmAccount, getWalletSigner, type SparkWalletInput } from 
 import type { LocalAccount } from "viem/accounts";
 import { encodeWithdrawSats, encodeWithdrawToken } from "./gateway";
 import { fetchNonce, fetchEip1559Fees } from "./evm";
-import { isTerminalIntentStatus, resolveExpiresAt } from "./types";
+import {
+  generateProofNonce,
+  isTerminalIntentStatus,
+  resolveExpiresAt,
+} from "./types";
 import type {
   CanonicalIntentAction,
   CanonicalIntentMessage,
   CanonicalTransferEntry,
   Deposit,
+  DepositRejection,
   ExecuteResponse,
   ExecutionSigner,
+  IndexedDepositProof,
   IntentStatus,
   IntentStatusResponse,
   NetworkInfo,
+  SignedDepositProof,
+  VerifyDepositsRequest,
+  VerifyDepositsResponse,
 } from "./types";
 
 /** Conversion factor: 1 sat = 10^10 wei on Flashnet's EVM. */
@@ -142,6 +151,53 @@ export interface DepositParams extends IntentExpiry {
   deposits: Deposit[];
   /** EVM address to credit. If omitted, credits the identity key's EVM address. */
   recipient?: string;
+  /**
+   * Optional explicit nonce (32 lowercase hex chars, no `0x`). When
+   * omitted the SDK generates one with {@link generateProofNonce}.
+   * Required to be set explicitly only when the caller is supplying
+   * pre-fetched `depositProof` values on `deposits[]` and needs the
+   * nonce to match the one those proofs were minted with.
+   */
+  nonce?: string;
+}
+
+/**
+ * Parameters for {@link ExecutionClient.verifyDeposit}.
+ */
+export interface VerifyDepositParams {
+  /**
+   * 16-byte nonce as 32 lowercase hex chars (no `0x`). Use
+   * {@link generateProofNonce} to generate one, then keep it for the
+   * subsequent `/execute` call. UUID-shaped nonces are not accepted on
+   * this endpoint.
+   */
+  nonce: string;
+  /**
+   * Spark transfer ids to verify. Accepts dashed UUID, plain hex, or
+   * `0x`-prefixed hex; the gateway canonicalises before lookup.
+   */
+  sparkTransferIds: string[];
+}
+
+/** Parameters for {@link ExecutionClient.depositWithProofs}. */
+export interface DepositWithProofsParams extends IntentExpiry {
+  /**
+   * Spark transfers funding this deposit. `depositProof` on each entry
+   * is populated by the call; callers should leave it unset.
+   */
+  deposits: Deposit[];
+  /** EVM address to credit. If omitted, credits the identity key's EVM address. */
+  recipient?: string;
+}
+
+/** Result of {@link ExecutionClient.depositWithProofs}. */
+export interface DepositWithProofsResult {
+  /** Per-transfer rejections from the verification step (empty on a fully-successful call). */
+  rejections: DepositRejection[];
+  /** The submission record from `/execute`. */
+  submission: ExecuteResponse;
+  /** The nonce that bound the proofs to the intent. */
+  nonce: string;
 }
 
 /** Parameters for a BTC withdrawal. */
@@ -326,6 +382,13 @@ export class ExecutionClient {
   /**
    * Submit a deposit intent.
    * Credits the deposited funds to the specified recipient or the identity key's EVM address.
+   *
+   * If `params.deposits[i].depositProof` is populated for every deposit,
+   * the proofs are attached to the request so the gateway can re-verify
+   * them in line. Otherwise the intent is submitted without proofs and
+   * falls back to the legacy admission path. Pass `params.nonce` to
+   * pin the value when supplying pre-fetched proofs; otherwise the SDK
+   * generates one.
    */
   async deposit(params: DepositParams): Promise<ExecuteResponse> {
     this.requireAuth();
@@ -341,7 +404,100 @@ export class ExecutionClient {
     return this.submitIntent(params.deposits, action, {
       recipient: recipient.toLowerCase(),
       expiresAt: params.expiresAt,
+      nonce: params.nonce,
     });
+  }
+
+  /**
+   * Verify a batch of Spark transfers and obtain signed deposit proofs
+   * for the ones the gateway can confirm.
+   *
+   * The returned proofs MUST be attached to the matching entries in
+   * `deposits[].depositProof` when calling `deposit` / `execute` with
+   * the same `params.nonce`; otherwise the gateway will not bind them
+   * to the intent. {@link depositWithProofs} performs both steps in
+   * one call and is the recommended path for most callers.
+   *
+   * Per-transfer failures (transfer not found, condition checks, etc.)
+   * land in `rejections[]` rather than aborting the whole request.
+   */
+  async verifyDeposit(
+    params: VerifyDepositParams
+  ): Promise<VerifyDepositsResponse> {
+    this.requireAuth();
+    if (!params.nonce || params.nonce.trim() === "") {
+      throw new Error("nonce is required");
+    }
+    if (!Array.isArray(params.sparkTransferIds) || params.sparkTransferIds.length === 0) {
+      throw new Error("sparkTransferIds must contain at least one entry");
+    }
+    const body: VerifyDepositsRequest = {
+      nonce: params.nonce,
+      transfers: params.sparkTransferIds.map((sparkTransferId) => ({
+        sparkTransferId,
+      })),
+    };
+    return this.post<VerifyDepositsResponse>("/api/v1/verifyDeposit", body, {
+      Authorization: `Bearer ${this.accessToken}`,
+    });
+  }
+
+  /**
+   * Fetch signed deposit proofs and submit a deposit intent in one
+   * call.
+   *
+   * Internally this picks a fresh nonce, calls `verifyDeposit` to
+   * obtain proofs for each transfer, attaches the proofs to the
+   * matching deposits, and submits the intent via `deposit`. If any
+   * transfer is rejected by the verification step, no `/execute` call
+   * is made; instead the result carries `rejections` and an error is
+   * thrown so the caller can branch on the rejection list.
+   */
+  async depositWithProofs(
+    params: DepositWithProofsParams
+  ): Promise<DepositWithProofsResult> {
+    this.requireAuth();
+    validateDeposits(params.deposits);
+
+    const nonce = generateProofNonce();
+    const verify = await this.verifyDeposit({
+      nonce,
+      sparkTransferIds: params.deposits.map((d) => d.sparkTransferId),
+    });
+
+    if (verify.rejections.length > 0) {
+      const summary = verify.rejections
+        .map((r) => `[${r.index}] ${r.sparkTransferId}: ${r.reason}`)
+        .join("; ");
+      throw new Error(
+        `verifyDeposit returned ${verify.rejections.length} rejection(s): ${summary}`
+      );
+    }
+    if (verify.proofs.length !== params.deposits.length) {
+      throw new Error(
+        `verifyDeposit returned ${verify.proofs.length} proofs for ${params.deposits.length} deposits`
+      );
+    }
+
+    const proofByIndex = new Map<number, SignedDepositProof>();
+    for (const p of verify.proofs as IndexedDepositProof[]) {
+      proofByIndex.set(p.index, p.proof);
+    }
+    const depositsWithProofs: Deposit[] = params.deposits.map((d, i) => {
+      const proof = proofByIndex.get(i);
+      if (!proof) {
+        throw new Error(`verifyDeposit response missing proof for index ${i}`);
+      }
+      return { ...d, depositProof: proof };
+    });
+
+    const submission = await this.deposit({
+      deposits: depositsWithProofs,
+      recipient: params.recipient,
+      expiresAt: params.expiresAt,
+      nonce,
+    });
+    return { rejections: [], submission, nonce };
   }
 
   /**
@@ -599,9 +755,15 @@ export class ExecutionClient {
       recipient?: string;
       evmTransaction?: string;
       expiresAt?: number;
+      nonce?: string;
     }
   ): Promise<ExecuteResponse> {
-    const nonce = crypto.randomUUID();
+    // Default to the 16-byte hex format. UUIDs are still accepted by the
+    // gateway on the proofless legacy path, but the proof flow requires
+    // 32 lowercase hex chars - using the proof-compatible shape for all
+    // new intents lets the same nonce flow into `/verifyDeposit` when
+    // proofs are added.
+    const nonce = requestAction.nonce ?? generateProofNonce();
     const expiresAt = resolveExpiresAt(requestAction.expiresAt);
 
     const transfers: CanonicalTransferEntry[] = deposits.map((d) => {
@@ -651,13 +813,23 @@ export class ExecutionClient {
     // Body mirrors the Rust `ExecuteRequest` struct. `amount` is u64 on
     // the Rust side; we emit bigints as numeric literals (not strings)
     // so serde_json parses them as u64 without any serde override.
+    //
+    // Each deposit may optionally carry a `depositProof` populated by
+    // an earlier `/verifyDeposit` call. The gateway re-verifies attached
+    // proofs in line; missing proofs fall through to the legacy path.
     const body: Record<string, unknown> = {
       chainId: this.config.chainId,
-      deposits: deposits.map((d) => ({
-        sparkTransferId: d.sparkTransferId,
-        asset: d.asset,
-        amount: d.amount,
-      })),
+      deposits: deposits.map((d) => {
+        const entry: Record<string, unknown> = {
+          sparkTransferId: d.sparkTransferId,
+          asset: d.asset,
+          amount: d.amount,
+        };
+        if (d.depositProof) {
+          entry.depositProof = d.depositProof;
+        }
+        return entry;
+      }),
       signature,
       nonce,
       expiresAt,

--- a/src/execution/client.ts
+++ b/src/execution/client.ts
@@ -145,24 +145,42 @@ export interface IntentExpiry {
   expiresAt?: number;
 }
 
+/**
+ * Mixin: opt out of the automatic proof-fetching step that
+ * `deposit` / `execute` perform on any deposit that arrives without a
+ * `depositProof`. Default is `false` (auto-fetch). Set `true` only
+ * when the caller has a reason to skip the verification step entirely
+ * (e.g. a benchmarking probe, or a flow where the gateway is known
+ * not to expose `/verifyDeposit`).
+ */
+export interface ProofOptOut {
+  skipProofs?: boolean;
+}
+
 /** Parameters for a deposit intent. */
-export interface DepositParams extends IntentExpiry {
-  /** Spark transfers funding this deposit. */
+export interface DepositParams extends IntentExpiry, ProofOptOut {
+  /**
+   * Spark transfers funding this deposit. Each entry that arrives
+   * without `depositProof` is automatically verified and proof-bound
+   * before the intent is signed - see `ProofOptOut` to disable.
+   */
   deposits: Deposit[];
   /** EVM address to credit. If omitted, credits the identity key's EVM address. */
   recipient?: string;
   /**
    * Optional explicit nonce (32 lowercase hex chars, no `0x`). When
    * omitted the SDK generates one with {@link generateProofNonce}.
-   * Required to be set explicitly only when the caller is supplying
-   * pre-fetched `depositProof` values on `deposits[]` and needs the
-   * nonce to match the one those proofs were minted with.
+   * Provide this only when the caller already holds matching
+   * `depositProof` values that were minted under a specific nonce.
    */
   nonce?: string;
 }
 
 /**
  * Parameters for {@link ExecutionClient.verifyDeposit}.
+ *
+ * This is the modular escape hatch - most callers should let
+ * `deposit` / `execute` handle proof fetching automatically.
  */
 export interface VerifyDepositParams {
   /**
@@ -177,27 +195,6 @@ export interface VerifyDepositParams {
    * `0x`-prefixed hex; the gateway canonicalises before lookup.
    */
   sparkTransferIds: string[];
-}
-
-/** Parameters for {@link ExecutionClient.depositWithProofs}. */
-export interface DepositWithProofsParams extends IntentExpiry {
-  /**
-   * Spark transfers funding this deposit. `depositProof` on each entry
-   * is populated by the call; callers should leave it unset.
-   */
-  deposits: Deposit[];
-  /** EVM address to credit. If omitted, credits the identity key's EVM address. */
-  recipient?: string;
-}
-
-/** Result of {@link ExecutionClient.depositWithProofs}. */
-export interface DepositWithProofsResult {
-  /** Per-transfer rejections from the verification step (empty on a fully-successful call). */
-  rejections: DepositRejection[];
-  /** The submission record from `/execute`. */
-  submission: ExecuteResponse;
-  /** The nonce that bound the proofs to the intent. */
-  nonce: string;
 }
 
 /** Parameters for a BTC withdrawal. */
@@ -233,11 +230,22 @@ export interface WaitForIntentOptions {
 }
 
 /** Parameters for a raw execute intent (advanced). */
-export interface ExecuteParams extends IntentExpiry {
-  /** Spark transfers to credit before executing. */
+export interface ExecuteParams extends IntentExpiry, ProofOptOut {
+  /**
+   * Spark transfers to credit before executing. Each entry without an
+   * attached `depositProof` is auto-verified before the intent is
+   * signed - see `ProofOptOut` to disable.
+   */
   deposits?: Deposit[];
   /** Hex-encoded signed EVM transaction (RLP-serialized, 0x-prefixed). */
   signedTx: string;
+  /**
+   * Optional explicit nonce (32 lowercase hex chars, no `0x`). When
+   * omitted the SDK generates one. Provide this only when the caller
+   * already holds matching `depositProof` values that were minted
+   * under a specific nonce.
+   */
+  nonce?: string;
 }
 
 /**
@@ -381,14 +389,20 @@ export class ExecutionClient {
 
   /**
    * Submit a deposit intent.
-   * Credits the deposited funds to the specified recipient or the identity key's EVM address.
    *
-   * If `params.deposits[i].depositProof` is populated for every deposit,
-   * the proofs are attached to the request so the gateway can re-verify
-   * them in line. Otherwise the intent is submitted without proofs and
-   * falls back to the legacy admission path. Pass `params.nonce` to
-   * pin the value when supplying pre-fetched proofs; otherwise the SDK
-   * generates one.
+   * Credits the deposited funds to the specified recipient or the
+   * identity key's EVM address. Any deposit that arrives without an
+   * attached `depositProof` is automatically proof-bound first by an
+   * internal `/verifyDeposit` call; the resulting proofs are stitched
+   * into the request the gateway receives. Pass `params.skipProofs:
+   * true` to opt out (rare), or pre-populate `deposits[i].depositProof`
+   * and `params.nonce` if proofs were fetched out of band.
+   *
+   * If the gateway has not enabled proof verification yet (returns
+   * 503) the call falls back to the legacy proofless path. Any
+   * per-transfer rejection from the verification step is surfaced as
+   * an error before the intent is signed - the SDK never silently
+   * drops or downgrades a deposit.
    */
   async deposit(params: DepositParams): Promise<ExecuteResponse> {
     this.requireAuth();
@@ -405,6 +419,7 @@ export class ExecutionClient {
       recipient: recipient.toLowerCase(),
       expiresAt: params.expiresAt,
       nonce: params.nonce,
+      skipProofs: params.skipProofs,
     });
   }
 
@@ -412,11 +427,12 @@ export class ExecutionClient {
    * Verify a batch of Spark transfers and obtain signed deposit proofs
    * for the ones the gateway can confirm.
    *
-   * The returned proofs MUST be attached to the matching entries in
-   * `deposits[].depositProof` when calling `deposit` / `execute` with
-   * the same `params.nonce`; otherwise the gateway will not bind them
-   * to the intent. {@link depositWithProofs} performs both steps in
-   * one call and is the recommended path for most callers.
+   * This is the **modular escape hatch**. `deposit` and `execute`
+   * already call into this method automatically for any deposit that
+   * arrives without a proof, so most callers do not need to invoke it
+   * directly. Reach for it only when the caller wants to inspect
+   * `rejections` before deciding whether to submit, cache proofs for
+   * later use, or otherwise stage the work in multiple steps.
    *
    * Per-transfer failures (transfer not found, condition checks, etc.)
    * land in `rejections[]` rather than aborting the whole request.
@@ -443,61 +459,84 @@ export class ExecutionClient {
   }
 
   /**
-   * Fetch signed deposit proofs and submit a deposit intent in one
-   * call.
+   * Auto-attach proofs for any deposit that arrives without one.
    *
-   * Internally this picks a fresh nonce, calls `verifyDeposit` to
-   * obtain proofs for each transfer, attaches the proofs to the
-   * matching deposits, and submits the intent via `deposit`. If any
-   * transfer is rejected by the verification step, no `/execute` call
-   * is made; instead the result carries `rejections` and an error is
-   * thrown so the caller can branch on the rejection list.
+   * Returns the (possibly mutated) deposit list plus the nonce that
+   * was used. If the caller already passed a nonce we honour it; if
+   * not, and at least one verification call was needed, we generate
+   * a proof-compatible 16-byte hex value via `generateProofNonce()`.
+   *
+   * On 503 from the gateway (proof verification not yet enabled),
+   * the call returns the inputs unchanged so the intent can be
+   * submitted on the legacy path. Any other failure - including a
+   * non-empty `rejections[]` - throws to surface the issue before
+   * the intent is signed.
    */
-  async depositWithProofs(
-    params: DepositWithProofsParams
-  ): Promise<DepositWithProofsResult> {
-    this.requireAuth();
-    validateDeposits(params.deposits);
+  private async resolveProofs(
+    deposits: Deposit[],
+    explicitNonce: string | undefined,
+    skipProofs: boolean | undefined
+  ): Promise<{ deposits: Deposit[]; nonce: string | undefined }> {
+    if (
+      skipProofs ||
+      deposits.length === 0 ||
+      deposits.every((d) => Boolean(d.depositProof))
+    ) {
+      return { deposits, nonce: explicitNonce };
+    }
 
-    const nonce = generateProofNonce();
-    const verify = await this.verifyDeposit({
-      nonce,
-      sparkTransferIds: params.deposits.map((d) => d.sparkTransferId),
-    });
+    const missing = deposits
+      .map((d, i) => (d.depositProof ? -1 : i))
+      .filter((i) => i >= 0);
 
-    if (verify.rejections.length > 0) {
-      const summary = verify.rejections
-        .map((r) => `[${r.index}] ${r.sparkTransferId}: ${r.reason}`)
+    const nonce = explicitNonce ?? generateProofNonce();
+    let response: VerifyDepositsResponse;
+    try {
+      response = await this.verifyDeposit({
+        nonce,
+        sparkTransferIds: missing.map((i) => deposits[i]!.sparkTransferId),
+      });
+    } catch (err) {
+      // Soft-mode fallback: if the gateway does not yet expose
+      // /verifyDeposit it returns 503. Fall through to the legacy
+      // proofless path instead of failing the caller's intent.
+      if (isGatewayUnavailable(err)) {
+        return { deposits, nonce: explicitNonce };
+      }
+      throw err;
+    }
+
+    if (response.rejections.length > 0) {
+      const summary = response.rejections
+        .map((r) => `[${missing[r.index] ?? r.index}] ${r.sparkTransferId}: ${r.reason} (${r.message})`)
         .join("; ");
       throw new Error(
-        `verifyDeposit returned ${verify.rejections.length} rejection(s): ${summary}`
+        `verifyDeposit returned ${response.rejections.length} rejection(s): ${summary}`
       );
     }
-    if (verify.proofs.length !== params.deposits.length) {
+    if (response.proofs.length !== missing.length) {
       throw new Error(
-        `verifyDeposit returned ${verify.proofs.length} proofs for ${params.deposits.length} deposits`
+        `verifyDeposit returned ${response.proofs.length} proofs for ${missing.length} unproven deposits`
       );
     }
 
-    const proofByIndex = new Map<number, SignedDepositProof>();
-    for (const p of verify.proofs as IndexedDepositProof[]) {
-      proofByIndex.set(p.index, p.proof);
+    const proofByMissingIndex = new Map<number, SignedDepositProof>();
+    for (const p of response.proofs as IndexedDepositProof[]) {
+      proofByMissingIndex.set(p.index, p.proof);
     }
-    const depositsWithProofs: Deposit[] = params.deposits.map((d, i) => {
-      const proof = proofByIndex.get(i);
-      if (!proof) {
-        throw new Error(`verifyDeposit response missing proof for index ${i}`);
-      }
-      return { ...d, depositProof: proof };
-    });
 
-    const submission = await this.deposit({
-      deposits: depositsWithProofs,
-      recipient: params.recipient,
-      expiresAt: params.expiresAt,
-      nonce,
-    });
-    return { rejections: [], submission, nonce };
+    const out = deposits.slice();
+    for (let i = 0; i < missing.length; i++) {
+      const originalIndex = missing[i]!;
+      const proof = proofByMissingIndex.get(i);
+      if (!proof) {
+        throw new Error(
+          `verifyDeposit response missing proof for transfer ${out[originalIndex]!.sparkTransferId}`
+        );
+      }
+      out[originalIndex] = { ...out[originalIndex]!, depositProof: proof };
+    }
+    return { deposits: out, nonce };
   }
 
   /**
@@ -568,7 +607,11 @@ export class ExecutionClient {
 
   /**
    * Submit a raw execute intent with a pre-signed EVM transaction.
-   * For advanced use — prefer `withdraw()` or AMMClient methods.
+   * For advanced use - prefer `withdraw()` or AMMClient methods.
+   *
+   * When `params.deposits` is non-empty, the same automatic proof
+   * attachment that `deposit()` does applies here. Set
+   * `params.skipProofs: true` to opt out.
    */
   async execute(params: ExecuteParams): Promise<ExecuteResponse> {
     this.requireAuth();
@@ -590,7 +633,12 @@ export class ExecutionClient {
     return this.submitIntent(
       deposits,
       { type: "execute", signedTxHash: txHash },
-      { evmTransaction: txHex, expiresAt: params.expiresAt }
+      {
+        evmTransaction: txHex,
+        expiresAt: params.expiresAt,
+        nonce: params.nonce,
+        skipProofs: params.skipProofs,
+      }
     );
   }
 
@@ -749,21 +797,31 @@ export class ExecutionClient {
   }
 
   private async submitIntent(
-    deposits: Deposit[],
+    rawDeposits: Deposit[],
     action: CanonicalIntentAction,
     requestAction: {
       recipient?: string;
       evmTransaction?: string;
       expiresAt?: number;
       nonce?: string;
+      skipProofs?: boolean;
     }
   ): Promise<ExecuteResponse> {
+    // Auto-attach proofs for any deposit that arrives without one.
+    // Falls through silently on a 503 from /verifyDeposit (soft-mode
+    // gateway), and throws on any per-transfer rejection.
+    const { deposits, nonce: resolvedNonce } = await this.resolveProofs(
+      rawDeposits,
+      requestAction.nonce,
+      requestAction.skipProofs
+    );
+
     // Default to the 16-byte hex format. UUIDs are still accepted by the
     // gateway on the proofless legacy path, but the proof flow requires
     // 32 lowercase hex chars - using the proof-compatible shape for all
     // new intents lets the same nonce flow into `/verifyDeposit` when
     // proofs are added.
-    const nonce = requestAction.nonce ?? generateProofNonce();
+    const nonce = resolvedNonce ?? generateProofNonce();
     const expiresAt = resolveExpiresAt(requestAction.expiresAt);
 
     const transfers: CanonicalTransferEntry[] = deposits.map((d) => {
@@ -929,6 +987,17 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
     };
     signal?.addEventListener("abort", onAbort, { once: true });
   });
+}
+
+/**
+ * Detect the "endpoint not (yet) available" 503 surface so callers
+ * can fall back to legacy behaviour without leaking the failure.
+ * Pattern-matches the error message thrown by `ExecutionClient.post`
+ * so we don't have to surface response.status through the type layer.
+ */
+function isGatewayUnavailable(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return /failed \(503\)/.test(err.message);
 }
 
 function validateDeposits(deposits: Deposit[]): void {

--- a/src/execution/deposit-proof.spec.ts
+++ b/src/execution/deposit-proof.spec.ts
@@ -1,6 +1,7 @@
 /**
- * Tests for the deposit-proof types and helpers.
+ * Tests for the deposit-proof types, helpers, and auto-attach flow.
  */
+import { ExecutionClient } from "./client";
 import {
   generateProofNonce,
   type SignedDepositProof,
@@ -9,6 +10,52 @@ import {
   type DepositRejection,
   type IndexedDepositProof,
 } from "./types";
+import type { SparkWalletInput } from "./spark-evm-account";
+import { secp256k1 } from "@noble/curves/secp256k1";
+
+const TEST_KEY = new Uint8Array(32);
+TEST_KEY[31] = 1;
+
+function mockWallet(): SparkWalletInput {
+  return {
+    config: {
+      signer: {
+        getIdentityPublicKey: async () =>
+          secp256k1.getPublicKey(TEST_KEY, true),
+        signMessageWithIdentityKey: async () => new Uint8Array(64),
+      },
+    },
+  } as unknown as SparkWalletInput;
+}
+
+const EXEC_CONFIG = {
+  gatewayUrl: "http://localhost:8080",
+  rpcUrl: "http://localhost:8545",
+  chainId: 21022,
+};
+
+function okResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function errorResponse(status: number, body = ""): Response {
+  return new Response(body, {
+    status,
+    statusText: status === 503 ? "Service Unavailable" : "Error",
+  });
+}
+
+const SAMPLE_PROOF: SignedDepositProof = {
+  payloadBytes: "deadbeef",
+  signature: "ab".repeat(64),
+};
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
 
 describe("generateProofNonce", () => {
   it("returns 32 lowercase hex chars (no 0x, no dashes)", () => {
@@ -24,7 +71,6 @@ describe("generateProofNonce", () => {
     for (let i = 0; i < 64; i++) {
       seen.add(generateProofNonce());
     }
-    // Collision odds on 16 random bytes over 64 draws are negligible.
     expect(seen.size).toBe(64);
   });
 });
@@ -42,11 +88,7 @@ describe("VerifyDeposit type round-trips", () => {
   });
 
   it("a response body with mixed proofs and rejections type-checks", () => {
-    const proof: SignedDepositProof = {
-      payloadBytes: "deadbeef",
-      signature: "00".repeat(64),
-    };
-    const ok: IndexedDepositProof = { index: 0, proof };
+    const ok: IndexedDepositProof = { index: 0, proof: SAMPLE_PROOF };
     const rej: DepositRejection = {
       index: 1,
       sparkTransferId: "00".repeat(16),
@@ -59,5 +101,198 @@ describe("VerifyDeposit type round-trips", () => {
     };
     expect(resp.proofs[0]?.proof.signature).toHaveLength(128);
     expect(resp.rejections[0]?.reason).toBe("transfer_not_found");
+  });
+});
+
+describe("ExecutionClient.deposit auto-attach flow", () => {
+  function authenticatedClient(fetchMock: jest.Mock): ExecutionClient {
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const client = new ExecutionClient(mockWallet(), EXEC_CONFIG);
+    // Bypass the real auth handshake.
+    (client as unknown as { accessToken: string }).accessToken = "test-token";
+    return client;
+  }
+
+  it("calls /verifyDeposit and attaches each proof before /execute", async () => {
+    const verifyResp: VerifyDepositsResponse = {
+      proofs: [{ index: 0, proof: SAMPLE_PROOF }],
+      rejections: [],
+    };
+    const executeResp = {
+      submissionId: "sub-1",
+      intentId: "0xabc",
+      status: "accepted",
+    };
+
+    const fetchMock = jest.fn(async (input: unknown, _init?: unknown) => {
+      const url = String(input);
+      if (url.endsWith("/api/v1/verifyDeposit")) return okResponse(verifyResp);
+      if (url.endsWith("/api/v1/execute")) return okResponse(executeResp);
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const client = authenticatedClient(fetchMock);
+    const result = await client.deposit({
+      deposits: [
+        {
+          sparkTransferId: "a1b2c3d4e5f60718a1b2c3d4e5f60718",
+          asset: { type: "btc" },
+          amount: 100_000n,
+        },
+      ],
+      recipient: "0x" + "01".repeat(20),
+    });
+
+    expect(result.submissionId).toBe("sub-1");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // Inspect the /execute body to confirm the proof was forwarded.
+    const executeCall = fetchMock.mock.calls.find((c) =>
+      String(c[0]).endsWith("/api/v1/execute")
+    );
+    if (!executeCall) throw new Error("/execute was not called");
+    const init = executeCall[1] as RequestInit;
+    const body = JSON.parse(String(init.body));
+    expect(body.deposits[0].depositProof).toEqual(SAMPLE_PROOF);
+    // Same nonce on both the /verifyDeposit call and the signed body.
+    const verifyCall = fetchMock.mock.calls.find((c) =>
+      String(c[0]).endsWith("/api/v1/verifyDeposit")
+    );
+    if (!verifyCall) throw new Error("/verifyDeposit was not called");
+    const verifyBody = JSON.parse(String((verifyCall[1] as RequestInit).body));
+    expect(verifyBody.nonce).toBe(body.nonce);
+    // And the nonce conforms to the 16-byte hex shape.
+    expect(verifyBody.nonce).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("skips /verifyDeposit when every deposit arrives with a proof", async () => {
+    const executeResp = {
+      submissionId: "sub-2",
+      intentId: "0xdef",
+      status: "accepted",
+    };
+    const fetchMock = jest.fn(async (input: unknown, _init?: unknown) => {
+      const url = String(input);
+      if (url.endsWith("/api/v1/execute")) return okResponse(executeResp);
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const client = authenticatedClient(fetchMock);
+    await client.deposit({
+      nonce: "ffeeddccbbaa99887766554433221100",
+      deposits: [
+        {
+          sparkTransferId: "a1b2c3d4e5f60718a1b2c3d4e5f60718",
+          asset: { type: "btc" },
+          amount: 100_000n,
+          depositProof: SAMPLE_PROOF,
+        },
+      ],
+      recipient: "0x" + "01".repeat(20),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]![0])).toContain("/api/v1/execute");
+  });
+
+  it("falls back to proofless /execute when /verifyDeposit returns 503", async () => {
+    const executeResp = {
+      submissionId: "sub-3",
+      intentId: "0xfeed",
+      status: "accepted",
+    };
+    const fetchMock = jest.fn(async (input: unknown, _init?: unknown) => {
+      const url = String(input);
+      if (url.endsWith("/api/v1/verifyDeposit")) return errorResponse(503);
+      if (url.endsWith("/api/v1/execute")) return okResponse(executeResp);
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const client = authenticatedClient(fetchMock);
+    const result = await client.deposit({
+      deposits: [
+        {
+          sparkTransferId: "a1b2c3d4e5f60718a1b2c3d4e5f60718",
+          asset: { type: "btc" },
+          amount: 100_000n,
+        },
+      ],
+      recipient: "0x" + "01".repeat(20),
+    });
+
+    expect(result.submissionId).toBe("sub-3");
+    const executeCall = fetchMock.mock.calls.find((c) =>
+      String(c[0]).endsWith("/api/v1/execute")
+    );
+    if (!executeCall) throw new Error("/execute was not called");
+    const body = JSON.parse(String((executeCall[1] as RequestInit).body));
+    expect(body.deposits[0].depositProof).toBeUndefined();
+  });
+
+  it("rejects when /verifyDeposit returns a rejection", async () => {
+    const verifyResp: VerifyDepositsResponse = {
+      proofs: [],
+      rejections: [
+        {
+          index: 0,
+          sparkTransferId: "a1b2c3d4e5f60718a1b2c3d4e5f60718",
+          reason: "condition_a_failed",
+          message: "sender mismatch",
+        },
+      ],
+    };
+    const fetchMock = jest.fn(async (_input: unknown, _init?: unknown) =>
+      okResponse(verifyResp)
+    );
+    const client = authenticatedClient(fetchMock);
+
+    await expect(
+      client.deposit({
+        deposits: [
+          {
+            sparkTransferId: "a1b2c3d4e5f60718a1b2c3d4e5f60718",
+            asset: { type: "btc" },
+            amount: 100_000n,
+          },
+        ],
+        recipient: "0x" + "01".repeat(20),
+      })
+    ).rejects.toThrow(/condition_a_failed/);
+
+    // /execute was never reached.
+    expect(
+      fetchMock.mock.calls.some((c) =>
+        String(c[0]).endsWith("/api/v1/execute")
+      )
+    ).toBe(false);
+  });
+
+  it("skipProofs:true bypasses /verifyDeposit entirely", async () => {
+    const executeResp = {
+      submissionId: "sub-4",
+      intentId: "0xbeef",
+      status: "accepted",
+    };
+    const fetchMock = jest.fn(async (input: unknown, _init?: unknown) => {
+      const url = String(input);
+      if (url.endsWith("/api/v1/execute")) return okResponse(executeResp);
+      throw new Error(`unexpected URL: ${url}`);
+    });
+    const client = authenticatedClient(fetchMock);
+
+    await client.deposit({
+      skipProofs: true,
+      deposits: [
+        {
+          sparkTransferId: "a1b2c3d4e5f60718a1b2c3d4e5f60718",
+          asset: { type: "btc" },
+          amount: 100_000n,
+        },
+      ],
+      recipient: "0x" + "01".repeat(20),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]![0])).toContain("/api/v1/execute");
   });
 });

--- a/src/execution/deposit-proof.spec.ts
+++ b/src/execution/deposit-proof.spec.ts
@@ -267,7 +267,7 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
     ).toBe(false);
   });
 
-  it("skipProofs:true bypasses /verifyDeposit entirely", async () => {
+  it("manualProofs:true bypasses /verifyDeposit entirely", async () => {
     const executeResp = {
       submissionId: "sub-4",
       intentId: "0xbeef",
@@ -281,7 +281,7 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
     const client = authenticatedClient(fetchMock);
 
     await client.deposit({
-      skipProofs: true,
+      manualProofs: true,
       deposits: [
         {
           sparkTransferId: "a1b2c3d4e5f60718a1b2c3d4e5f60718",
@@ -294,5 +294,55 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(String(fetchMock.mock.calls[0]![0])).toContain("/api/v1/execute");
+  });
+
+  it("throws when pre-attached proofs are passed without a matching nonce", async () => {
+    // The SDK cannot reconstruct the nonce that minted a pre-attached
+    // proof, so it must come from the caller. Catch this before
+    // signing rather than letting the gateway reject for a binding
+    // mismatch at submit time.
+    const fetchMock = jest.fn(async (_input: unknown, _init?: unknown) =>
+      okResponse({})
+    );
+    const client = authenticatedClient(fetchMock);
+
+    await expect(
+      client.deposit({
+        deposits: [
+          {
+            sparkTransferId: "a1b2c3d4e5f60718a1b2c3d4e5f60718",
+            asset: { type: "btc" },
+            amount: 100_000n,
+            depositProof: SAMPLE_PROOF,
+          },
+        ],
+        recipient: "0x" + "01".repeat(20),
+      })
+    ).rejects.toThrow(/pre-attached depositProof entries but no nonce/);
+
+    // No HTTP call escaped the SDK.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("throws on a malformed pre-attached proof signature", async () => {
+    const fetchMock = jest.fn(async () => okResponse({}));
+    const client = authenticatedClient(fetchMock);
+
+    await expect(
+      client.deposit({
+        nonce: "ffeeddccbbaa99887766554433221100",
+        deposits: [
+          {
+            sparkTransferId: "a1b2c3d4e5f60718a1b2c3d4e5f60718",
+            asset: { type: "btc" },
+            amount: 100_000n,
+            depositProof: { payloadBytes: "deadbeef", signature: "tooshort" },
+          },
+        ],
+        recipient: "0x" + "01".repeat(20),
+      })
+    ).rejects.toThrow(/signature must be 64 hex bytes/);
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/src/execution/deposit-proof.spec.ts
+++ b/src/execution/deposit-proof.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for the deposit-proof types and helpers.
+ */
+import {
+  generateProofNonce,
+  type SignedDepositProof,
+  type VerifyDepositsRequest,
+  type VerifyDepositsResponse,
+  type DepositRejection,
+  type IndexedDepositProof,
+} from "./types";
+
+describe("generateProofNonce", () => {
+  it("returns 32 lowercase hex chars (no 0x, no dashes)", () => {
+    const n = generateProofNonce();
+    expect(n).toHaveLength(32);
+    expect(n).toMatch(/^[0-9a-f]{32}$/);
+    expect(n.includes("-")).toBe(false);
+    expect(n.startsWith("0x")).toBe(false);
+  });
+
+  it("produces distinct values on successive calls", () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 64; i++) {
+      seen.add(generateProofNonce());
+    }
+    // Collision odds on 16 random bytes over 64 draws are negligible.
+    expect(seen.size).toBe(64);
+  });
+});
+
+describe("VerifyDeposit type round-trips", () => {
+  it("a request body shaped per the OpenAPI contract type-checks", () => {
+    const req: VerifyDepositsRequest = {
+      nonce: generateProofNonce(),
+      transfers: [
+        { sparkTransferId: "a1b2c3d4e5f60718a1b2c3d4e5f60718" },
+        { sparkTransferId: "0x" + "ab".repeat(32) },
+      ],
+    };
+    expect(req.transfers).toHaveLength(2);
+  });
+
+  it("a response body with mixed proofs and rejections type-checks", () => {
+    const proof: SignedDepositProof = {
+      payloadBytes: "deadbeef",
+      signature: "00".repeat(64),
+    };
+    const ok: IndexedDepositProof = { index: 0, proof };
+    const rej: DepositRejection = {
+      index: 1,
+      sparkTransferId: "00".repeat(16),
+      reason: "transfer_not_found",
+      message: "no rows",
+    };
+    const resp: VerifyDepositsResponse = {
+      proofs: [ok],
+      rejections: [rej],
+    };
+    expect(resp.proofs[0]?.proof.signature).toHaveLength(128);
+    expect(resp.rejections[0]?.reason).toBe("transfer_not_found");
+  });
+});

--- a/src/execution/deposit-proof.spec.ts
+++ b/src/execution/deposit-proof.spec.ts
@@ -129,6 +129,33 @@ describe("canonicalIntentId", () => {
     });
     expect(a).toEqual(b);
   });
+
+  it("treats a dashed-UUID transferId the same as its bare-hex form", () => {
+    const action: CanonicalIntentAction = {
+      type: "deposit",
+      recipient: RECIPIENT,
+    };
+    const mk = (transferId: string): CanonicalTransferEntry => ({
+      transferId,
+      amount: "0x186a0",
+      asset: { type: "NATIVE_SATS" },
+      depositProof: PLACEHOLDER_DEPOSIT_PROOF,
+    });
+    const dashed = canonicalIntentId({
+      chainId: 21022,
+      transfers: [mk("a1b2c3d4-e5f6-0718-a1b2-c3d4e5f60718")],
+      action,
+      recipientForHash: RECIPIENT,
+    });
+    const bare = canonicalIntentId({
+      chainId: 21022,
+      transfers: [mk("a1b2c3d4e5f60718a1b2c3d4e5f60718")],
+      action,
+      recipientForHash: RECIPIENT,
+    });
+    expect(dashed).toEqual(bare);
+    expect(dashed).toMatch(/^[0-9a-f]{64}$/);
+  });
 });
 
 describe("VerifyDeposit type round-trips", () => {

--- a/src/execution/deposit-proof.spec.ts
+++ b/src/execution/deposit-proof.spec.ts
@@ -3,12 +3,15 @@
  */
 import { ExecutionClient, VerifyDepositRejectedError } from "./client";
 import {
-  generateProofNonce,
+  PLACEHOLDER_DEPOSIT_PROOF,
+  canonicalIntentId,
+  type CanonicalIntentAction,
+  type CanonicalTransferEntry,
+  type DepositRejection,
+  type IndexedDepositProof,
   type SignedDepositProof,
   type VerifyDepositsRequest,
   type VerifyDepositsResponse,
-  type DepositRejection,
-  type IndexedDepositProof,
 } from "./types";
 import type { SparkWalletInput } from "./spark-evm-account";
 import { secp256k1 } from "@noble/curves/secp256k1";
@@ -62,38 +65,83 @@ const SAMPLE_PROOF_0X: SignedDepositProof = {
   signature: "0x" + "ab".repeat(64),
 };
 
+const RECIPIENT = "0x" + "01".repeat(20);
+
 afterEach(() => {
   jest.restoreAllMocks();
 });
 
-describe("generateProofNonce", () => {
-  it("returns 32 lowercase hex chars (no 0x, no dashes)", () => {
-    const n = generateProofNonce();
-    expect(n).toHaveLength(32);
-    expect(n).toMatch(/^[0-9a-f]{32}$/);
-    expect(n.includes("-")).toBe(false);
-    expect(n.startsWith("0x")).toBe(false);
+describe("canonicalIntentId", () => {
+  it("returns 64 lowercase hex chars (32-byte BLAKE3 output)", () => {
+    const id = canonicalIntentId({
+      chainId: 21022,
+      transfers: [],
+      action: { type: "deposit", recipient: RECIPIENT },
+      recipientForHash: RECIPIENT,
+    });
+    expect(id).toHaveLength(64);
+    expect(id).toMatch(/^[0-9a-f]{64}$/);
   });
 
-  it("produces distinct values on successive calls", () => {
-    const seen = new Set<string>();
-    for (let i = 0; i < 64; i++) {
-      seen.add(generateProofNonce());
-    }
-    expect(seen.size).toBe(64);
+  it("changes when the action recipient changes", () => {
+    const a = canonicalIntentId({
+      chainId: 21022,
+      transfers: [],
+      action: { type: "deposit", recipient: RECIPIENT },
+      recipientForHash: RECIPIENT,
+    });
+    const otherRecipient = "0x" + "02".repeat(20);
+    const b = canonicalIntentId({
+      chainId: 21022,
+      transfers: [],
+      action: { type: "deposit", recipient: otherRecipient },
+      recipientForHash: otherRecipient,
+    });
+    expect(a).not.toEqual(b);
+  });
+
+  it("is stable across `depositProof` field changes (proof not in preimage)", () => {
+    const action: CanonicalIntentAction = {
+      type: "deposit",
+      recipient: RECIPIENT,
+    };
+    const baseTransfer: CanonicalTransferEntry = {
+      transferId: "a1b2c3d4e5f60718a1b2c3d4e5f60718",
+      amount: "0x186a0",
+      asset: { type: "NATIVE_SATS" },
+      depositProof: PLACEHOLDER_DEPOSIT_PROOF,
+    };
+    const withProof: CanonicalTransferEntry = {
+      ...baseTransfer,
+      depositProof: SAMPLE_PROOF,
+    };
+    const a = canonicalIntentId({
+      chainId: 21022,
+      transfers: [baseTransfer],
+      action,
+      recipientForHash: RECIPIENT,
+    });
+    const b = canonicalIntentId({
+      chainId: 21022,
+      transfers: [withProof],
+      action,
+      recipientForHash: RECIPIENT,
+    });
+    expect(a).toEqual(b);
   });
 });
 
 describe("VerifyDeposit type round-trips", () => {
   it("a request body shaped per the OpenAPI contract type-checks", () => {
     const req: VerifyDepositsRequest = {
-      nonce: generateProofNonce(),
+      intentId: "0".repeat(64),
       transfers: [
         { sparkTransferId: "a1b2c3d4e5f60718a1b2c3d4e5f60718" },
         { sparkTransferId: "0x" + "ab".repeat(32) },
       ],
     };
     expect(req.transfers).toHaveLength(2);
+    expect(req.intentId).toHaveLength(64);
   });
 
   it("a response body with mixed proofs and rejections type-checks", () => {
@@ -122,7 +170,7 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
     return client;
   }
 
-  it("calls /verifyDeposit and attaches each proof before /execute", async () => {
+  it("calls /verifyDeposit with the canonical intentId and attaches each proof before /execute", async () => {
     const verifyResp: VerifyDepositsResponse = {
       proofs: [{ index: 0, proof: SAMPLE_PROOF }],
       rejections: [],
@@ -149,7 +197,7 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
           amount: 100_000n,
         },
       ],
-      recipient: "0x" + "01".repeat(20),
+      recipient: RECIPIENT,
     });
 
     expect(result.submissionId).toBe("sub-1");
@@ -163,15 +211,37 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
     const init = executeCall[1] as RequestInit;
     const body = JSON.parse(String(init.body));
     expect(body.deposits[0].depositProof).toEqual(SAMPLE_PROOF);
-    // Same nonce on both the /verifyDeposit call and the signed body.
+    // Wire shape: amount is U256 hex, asset uses SCREAMING_SNAKE_CASE tag.
+    expect(body.deposits[0].amount).toBe("0x186a0");
+    expect(body.deposits[0].asset).toEqual({ type: "NATIVE_SATS" });
+    // No top-level `nonce` field — replay defense is structural via intent_id.
+    expect(body.nonce).toBeUndefined();
+
+    // /verifyDeposit body carries the canonical intentId, not a random nonce.
     const verifyCall = fetchMock.mock.calls.find((c) =>
       String(c[0]).endsWith("/api/v1/verifyDeposit")
     );
     if (!verifyCall) throw new Error("/verifyDeposit was not called");
     const verifyBody = JSON.parse(String((verifyCall[1] as RequestInit).body));
-    expect(verifyBody.nonce).toBe(body.nonce);
-    // And the nonce conforms to the 16-byte hex shape.
-    expect(verifyBody.nonce).toMatch(/^[0-9a-f]{32}$/);
+    expect(verifyBody.nonce).toBeUndefined();
+    expect(verifyBody.intentId).toMatch(/^[0-9a-f]{64}$/);
+
+    // The intentId in the verify body matches what the SDK would compute
+    // from the same canonical preimage.
+    const expectedIntentId = canonicalIntentId({
+      chainId: EXEC_CONFIG.chainId,
+      transfers: [
+        {
+          transferId: "a1b2c3d4e5f60718a1b2c3d4e5f60718",
+          amount: "0x186a0",
+          asset: { type: "NATIVE_SATS" },
+          depositProof: PLACEHOLDER_DEPOSIT_PROOF,
+        },
+      ],
+      action: { type: "deposit", recipient: RECIPIENT.toLowerCase() },
+      recipientForHash: RECIPIENT.toLowerCase(),
+    });
+    expect(verifyBody.intentId).toEqual(expectedIntentId);
   });
 
   it("skips /verifyDeposit when every deposit arrives with a proof", async () => {
@@ -188,7 +258,6 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
 
     const client = authenticatedClient(fetchMock);
     await client.deposit({
-      nonce: "ffeeddccbbaa99887766554433221100",
       deposits: [
         {
           sparkTransferId: "a1b2c3d4e5f60718a1b2c3d4e5f60718",
@@ -197,14 +266,14 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
           depositProof: SAMPLE_PROOF,
         },
       ],
-      recipient: "0x" + "01".repeat(20),
+      recipient: RECIPIENT,
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(String(fetchMock.mock.calls[0]![0])).toContain("/api/v1/execute");
   });
 
-  it("falls back to proofless /execute when /verifyDeposit returns 503", async () => {
+  it("falls back to /execute with a placeholder proof when /verifyDeposit returns 503", async () => {
     const executeResp = {
       submissionId: "sub-3",
       intentId: "0xfeed",
@@ -226,7 +295,7 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
           amount: 100_000n,
         },
       ],
-      recipient: "0x" + "01".repeat(20),
+      recipient: RECIPIENT,
     });
 
     expect(result.submissionId).toBe("sub-3");
@@ -235,7 +304,10 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
     );
     if (!executeCall) throw new Error("/execute was not called");
     const body = JSON.parse(String((executeCall[1] as RequestInit).body));
-    expect(body.deposits[0].depositProof).toBeUndefined();
+    // On 503 the placeholder shape is sent — the gateway's
+    // has_valid_shape() treats it as "not configured" and falls through
+    // to the legacy admission path.
+    expect(body.deposits[0].depositProof).toEqual(PLACEHOLDER_DEPOSIT_PROOF);
   });
 
   it("rejects with a typed VerifyDepositRejectedError carrying structured rejections", async () => {
@@ -265,7 +337,7 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
             amount: 100_000n,
           },
         ],
-        recipient: "0x" + "01".repeat(20),
+        recipient: RECIPIENT,
       });
     } catch (e) {
       caught = e;
@@ -302,7 +374,6 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
     const client = authenticatedClient(fetchMock);
 
     await client.deposit({
-      nonce: "ffeeddccbbaa99887766554433221100",
       deposits: [
         {
           sparkTransferId: "a1b2c3d4e5f60718a1b2c3d4e5f60718",
@@ -311,7 +382,7 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
           depositProof: SAMPLE_PROOF_0X,
         },
       ],
-      recipient: "0x" + "01".repeat(20),
+      recipient: RECIPIENT,
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -343,39 +414,19 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
           amount: 100_000n,
         },
       ],
-      recipient: "0x" + "01".repeat(20),
+      recipient: RECIPIENT,
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(String(fetchMock.mock.calls[0]![0])).toContain("/api/v1/execute");
-  });
-
-  it("throws when pre-attached proofs are passed without a matching nonce", async () => {
-    // The SDK cannot reconstruct the nonce that minted a pre-attached
-    // proof, so it must come from the caller. Catch this before
-    // signing rather than letting the gateway reject for a binding
-    // mismatch at submit time.
-    const fetchMock = jest.fn(async (_input: unknown, _init?: unknown) =>
-      okResponse({})
+    // manualProofs skips /verifyDeposit, but the wire requires a
+    // `depositProof` field on every Deposit. The SDK fills missing
+    // proofs with the placeholder shape — has_valid_shape() returns
+    // false, so the gateway falls through to legacy admission.
+    const body = JSON.parse(
+      String((fetchMock.mock.calls[0]![1] as RequestInit).body)
     );
-    const client = authenticatedClient(fetchMock);
-
-    await expect(
-      client.deposit({
-        deposits: [
-          {
-            sparkTransferId: "a1b2c3d4e5f60718a1b2c3d4e5f60718",
-            asset: { type: "btc" },
-            amount: 100_000n,
-            depositProof: SAMPLE_PROOF,
-          },
-        ],
-        recipient: "0x" + "01".repeat(20),
-      })
-    ).rejects.toThrow(/pre-attached depositProof entries but no nonce/);
-
-    // No HTTP call escaped the SDK.
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(body.deposits[0].depositProof).toEqual(PLACEHOLDER_DEPOSIT_PROOF);
   });
 
   it("throws on a malformed pre-attached proof signature", async () => {
@@ -384,7 +435,6 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
 
     await expect(
       client.deposit({
-        nonce: "ffeeddccbbaa99887766554433221100",
         deposits: [
           {
             sparkTransferId: "a1b2c3d4e5f60718a1b2c3d4e5f60718",
@@ -393,7 +443,7 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
             depositProof: { payloadBytes: "deadbeef", signature: "tooshort" },
           },
         ],
-        recipient: "0x" + "01".repeat(20),
+        recipient: RECIPIENT,
       })
     ).rejects.toThrow(/signature must be 64 hex bytes/);
 

--- a/src/execution/deposit-proof.spec.ts
+++ b/src/execution/deposit-proof.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for the deposit-proof types, helpers, and auto-attach flow.
  */
-import { ExecutionClient } from "./client";
+import { ExecutionClient, VerifyDepositRejectedError } from "./client";
 import {
   generateProofNonce,
   type SignedDepositProof,
@@ -48,9 +48,18 @@ function errorResponse(status: number, body = ""): Response {
   });
 }
 
+// Bare-hex shape (the gateway accepts both bare and 0x-prefixed on input).
 const SAMPLE_PROOF: SignedDepositProof = {
   payloadBytes: "deadbeef",
   signature: "ab".repeat(64),
+};
+
+// 0x-prefixed shape (the gateway emits this on /verifyDeposit responses
+// via serde_bytes_hex, so any proof flowing through the BYO path will
+// carry the prefix).
+const SAMPLE_PROOF_0X: SignedDepositProof = {
+  payloadBytes: "0xdeadbeef",
+  signature: "0x" + "ab".repeat(64),
 };
 
 afterEach(() => {
@@ -229,7 +238,7 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
     expect(body.deposits[0].depositProof).toBeUndefined();
   });
 
-  it("rejects when /verifyDeposit returns a rejection", async () => {
+  it("rejects with a typed VerifyDepositRejectedError carrying structured rejections", async () => {
     const verifyResp: VerifyDepositsResponse = {
       proofs: [],
       rejections: [
@@ -246,8 +255,9 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
     );
     const client = authenticatedClient(fetchMock);
 
-    await expect(
-      client.deposit({
+    let caught: unknown;
+    try {
+      await client.deposit({
         deposits: [
           {
             sparkTransferId: "a1b2c3d4e5f60718a1b2c3d4e5f60718",
@@ -256,8 +266,15 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
           },
         ],
         recipient: "0x" + "01".repeat(20),
-      })
-    ).rejects.toThrow(/condition_a_failed/);
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(VerifyDepositRejectedError);
+    const rej = (caught as VerifyDepositRejectedError).rejections;
+    expect(rej).toHaveLength(1);
+    expect(rej[0]?.reason).toBe("condition_a_failed");
+    expect(rej[0]?.index).toBe(0);
 
     // /execute was never reached.
     expect(
@@ -265,6 +282,43 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
         String(c[0]).endsWith("/api/v1/execute")
       )
     ).toBe(false);
+  });
+
+  it("accepts a 0x-prefixed pre-attached proof (server response shape)", async () => {
+    // The gateway emits proofs with a leading `0x` on payloadBytes
+    // and signature via serde_bytes_hex. Confirm the SDK doesn't
+    // reject a proof captured directly from /verifyDeposit and
+    // re-passed on /execute via the BYO path.
+    const executeResp = {
+      submissionId: "sub-byo",
+      intentId: "0xfeed",
+      status: "accepted",
+    };
+    const fetchMock = jest.fn(async (input: unknown, _init?: unknown) => {
+      const url = String(input);
+      if (url.endsWith("/api/v1/execute")) return okResponse(executeResp);
+      throw new Error(`unexpected URL: ${url}`);
+    });
+    const client = authenticatedClient(fetchMock);
+
+    await client.deposit({
+      nonce: "ffeeddccbbaa99887766554433221100",
+      deposits: [
+        {
+          sparkTransferId: "a1b2c3d4e5f60718a1b2c3d4e5f60718",
+          asset: { type: "btc" },
+          amount: 100_000n,
+          depositProof: SAMPLE_PROOF_0X,
+        },
+      ],
+      recipient: "0x" + "01".repeat(20),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      String((fetchMock.mock.calls[0]![1] as RequestInit).body)
+    );
+    expect(body.deposits[0].depositProof).toEqual(SAMPLE_PROOF_0X);
   });
 
   it("manualProofs:true bypasses /verifyDeposit entirely", async () => {

--- a/src/execution/deposit-proof.spec.ts
+++ b/src/execution/deposit-proof.spec.ts
@@ -201,6 +201,8 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
     });
 
     expect(result.submissionId).toBe("sub-1");
+    // POST /execute returns lowercase "accepted"; the SDK canonicalizes it.
+    expect(result.status).toBe("ACCEPTED");
     expect(fetchMock).toHaveBeenCalledTimes(2);
 
     // Inspect the /execute body to confirm the proof was forwarded.

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -35,6 +35,7 @@ export {
   type WaitForIntentOptions,
   type VerifyDepositParams,
   type ProofOptOut,
+  VerifyDepositRejectedError,
 } from "./client";
 
 // SparkWallet → EVM account adapter

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -34,8 +34,7 @@ export {
   type ExecuteParams,
   type WaitForIntentOptions,
   type VerifyDepositParams,
-  type DepositWithProofsParams,
-  type DepositWithProofsResult,
+  type ProofOptOut,
 } from "./client";
 
 // SparkWallet → EVM account adapter

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -124,6 +124,7 @@ export {
   canonicalIntentId,
   depositAssetToWire,
   isTerminalIntentStatus,
+  normalizeIntentStatus,
   resolveExpiresAt,
   u256Hex,
 } from "./types";

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -97,6 +97,7 @@ export {
 
 // Types
 export type {
+  Asset,
   CanonicalIntentAction,
   CanonicalIntentMessage,
   CanonicalTransferEntry,
@@ -119,9 +120,12 @@ export type {
 export {
   DEFAULT_INTENT_TTL_MS,
   TERMINAL_INTENT_STATUSES,
-  generateProofNonce,
+  PLACEHOLDER_DEPOSIT_PROOF,
+  canonicalIntentId,
+  depositAssetToWire,
   isTerminalIntentStatus,
   resolveExpiresAt,
+  u256Hex,
 } from "./types";
 
 // Revert reason decoding

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -33,6 +33,9 @@ export {
   type WithdrawTokenParams,
   type ExecuteParams,
   type WaitForIntentOptions,
+  type VerifyDepositParams,
+  type DepositWithProofsParams,
+  type DepositWithProofsResult,
 } from "./client";
 
 // SparkWallet → EVM account adapter
@@ -99,17 +102,24 @@ export type {
   CanonicalTransferEntry,
   Deposit,
   DepositAsset,
+  DepositRejection,
   ExecuteResponse,
   ExecutionSigner,
+  IndexedDepositProof,
   IntentStatus,
   IntentStatusResponse,
   NetworkInfo,
+  SignedDepositProof,
   SparkNetworkInfo,
   ExecutionNetworkInfo,
+  VerifyDepositsRequest,
+  VerifyDepositsResponse,
+  VerifyDepositTransfer,
 } from "./types";
 export {
   DEFAULT_INTENT_TTL_MS,
   TERMINAL_INTENT_STATUSES,
+  generateProofNonce,
   isTerminalIntentStatus,
   resolveExpiresAt,
 } from "./types";

--- a/src/execution/stringify-bigint.spec.ts
+++ b/src/execution/stringify-bigint.spec.ts
@@ -96,41 +96,50 @@ describe("stringifyWithBigint", () => {
   // Golden-vector regression guarding the field ordering on the signed
   // canonical intent message. The validator hashes the JSON output
   // byte-for-byte and the signed bytes must match the Rust
-  // CanonicalIntentMessage struct (chainId, transfers, action, nonce, expiresAt),
-  // with each CanonicalTransferEntry in the order
-  // (transferId, amountSats, assetType, tokenId?). If someone reorders
-  // the TS interface, the Rust struct, or the object literal in
+  // CanonicalIntentMessage struct (chainId, transfers, action,
+  // expiresAt — no `nonce` since migration 0008), with each
+  // CanonicalTransferEntry in the order
+  // (transferId, amount, asset, depositProof). If someone reorders the
+  // TS interface, the Rust struct, or the object literal in
   // ExecutionClient.submitIntent, this test will fail loudly instead of
   // breaking signature verification at runtime.
   it("canonical intent message matches the Rust struct field order", () => {
     const transfers: CanonicalTransferEntry[] = [
       {
         transferId: "transfer-1",
-        amountSats: 1000n,
-        assetType: "NativeSats",
+        amount: "0x3e8",
+        asset: { type: "NATIVE_SATS" },
+        depositProof: { payloadBytes: "0x", signature: "0x" },
       },
       {
         transferId: "transfer-2",
-        amountSats: 2500n,
-        assetType: "SparkToken",
-        tokenId: "btkn1foo",
+        amount: "0x9c4",
+        asset: {
+          type: "SPARK_TOKEN",
+          tokenId:
+            "0x0000000000000000000000000000000000000000000000000000000000000001",
+        },
+        depositProof: {
+          payloadBytes: "0xdeadbeef",
+          signature: "0x" + "ab".repeat(64),
+        },
       },
     ];
     const message: CanonicalIntentMessage = {
       chainId: 21022,
       transfers,
       action: { type: "deposit", recipient: "0xabc" },
-      nonce: "nonce-xyz",
       expiresAt: 1_893_456_000_000,
     };
     expect(stringifyWithBigint(message)).toEqual(
       '{"chainId":21022,' +
         '"transfers":[' +
-        '{"transferId":"transfer-1","amountSats":1000,"assetType":"NativeSats"},' +
-        '{"transferId":"transfer-2","amountSats":2500,"assetType":"SparkToken","tokenId":"btkn1foo"}' +
+        '{"transferId":"transfer-1","amount":"0x3e8","asset":{"type":"NATIVE_SATS"},"depositProof":{"payloadBytes":"0x","signature":"0x"}},' +
+        '{"transferId":"transfer-2","amount":"0x9c4","asset":{"type":"SPARK_TOKEN","tokenId":"0x0000000000000000000000000000000000000000000000000000000000000001"},"depositProof":{"payloadBytes":"0xdeadbeef","signature":"0x' +
+        "ab".repeat(64) +
+        '"}}' +
         "]," +
         '"action":{"type":"deposit","recipient":"0xabc"},' +
-        '"nonce":"nonce-xyz",' +
         '"expiresAt":1893456000000}'
     );
   });

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -24,8 +24,8 @@ export interface Deposit {
    * When present, the gateway re-verifies the proof on `/execute` before
    * forwarding the intent. When absent, the intent falls back to the
    * legacy admission path that polls the operator side until confirmation.
-   * Higher-level callers should prefer `ExecutionClient.depositWithProofs`,
-   * which fetches proofs and attaches them in one call.
+   * Higher-level callers should prefer {@link ExecutionClient.deposit},
+   * which auto-fetches and attaches proofs before submitting the intent.
    */
   depositProof?: SignedDepositProof;
 }
@@ -33,11 +33,12 @@ export interface Deposit {
 /**
  * Signed deposit proof returned by `POST /api/v1/verifyDeposit`.
  *
- * `payloadBytes` is an opaque byte string (lowercase hex, no 0x prefix)
- * carrying the canonical proof payload. `signature` is the compact ECDSA
- * signature over that payload as 64 lowercase hex bytes (no 0x prefix).
- * Callers should treat both fields as opaque and pass the value through
- * unchanged when submitting the intent.
+ * Both fields are hex-encoded byte strings; the gateway accepts the
+ * value with or without a leading `0x` and emits it with the prefix.
+ * `payloadBytes` is opaque (canonical proof payload, variable length)
+ * and `signature` is the compact 64-byte ECDSA signature over it.
+ * Callers should treat both fields as opaque and pass the value
+ * through unchanged when submitting the intent.
  */
 export interface SignedDepositProof {
   payloadBytes: string;

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -144,38 +144,55 @@ export interface ExecuteResponse {
 /**
  * Lifecycle status of an intent on the execution gateway.
  *
- * Wire format mirrors the Rust enum (snake_case strings). Use this as the
- * source of truth when polling — `getIntentStatus()` and `waitForIntent()`
- * both return / target values from this set.
+ * Wire format mirrors the Rust `IntentStatus` enum, which serializes as
+ * SCREAMING_SNAKE_CASE (`crates/storage/execution-store/src/lib.rs`). The
+ * authoritative `GET /api/v1/intents/{id}` endpoint returns exactly these
+ * four values.
  *
- * Lifecycle order under the happy path is roughly:
- *   `accepted → oracle_pending? → included_pending_finality → finalized`
+ * Lifecycle order under the happy path:
+ *   `ACCEPTED → INCLUDED_PENDING_FINALITY → FINALIZED`
  *
- * Terminal failure states are `rejected` and `expired`. `oracle_pending` is
- * only entered for deposit-shaped intents waiting on Spark operator-DB
- * confirmation; pure-execute intents skip it.
+ * `EXPIRED` is the single terminal failure state. The v1 `REJECTED` and
+ * `ORACLE_PENDING` sub-states were collapsed in migration 0008 (rejected →
+ * `EXPIRED` with the original failure kind carried in `statusMessage`;
+ * oracle-pending → `ACCEPTED`).
+ *
+ * Note: `POST /api/v1/execute` returns the initial status as the lowercase
+ * string `"accepted"`. The SDK normalizes every status it surfaces to the
+ * canonical SCREAMING_SNAKE_CASE form via {@link normalizeIntentStatus}.
  */
 export type IntentStatus =
-  | "accepted"
-  | "oracle_pending"
-  | "included_pending_finality"
-  | "finalized"
-  | "rejected"
-  | "expired";
+  | "ACCEPTED"
+  | "INCLUDED_PENDING_FINALITY"
+  | "FINALIZED"
+  | "EXPIRED";
 
 /** Statuses that represent terminal lifecycle states (no further updates). */
 export const TERMINAL_INTENT_STATUSES = [
-  "finalized",
-  "rejected",
-  "expired",
+  "FINALIZED",
+  "EXPIRED",
 ] as const satisfies readonly IntentStatus[];
+
+/**
+ * Normalize a raw status string from any gateway endpoint to the canonical
+ * {@link IntentStatus} (SCREAMING_SNAKE_CASE). Tolerates the lowercase
+ * `"accepted"` that `POST /execute` returns and any case the gateway emits.
+ * Unknown values are upper-cased and returned as-is so forward-compatible
+ * statuses don't throw.
+ */
+export function normalizeIntentStatus(raw: string): IntentStatus {
+  return raw.toUpperCase() as IntentStatus;
+}
 
 /**
  * Returns true when the status is a terminal lifecycle state — i.e. the
  * intent has reached a final outcome and will receive no further updates.
+ * Accepts any case; normalizes before comparing.
  */
-export function isTerminalIntentStatus(status: IntentStatus): boolean {
-  return (TERMINAL_INTENT_STATUSES as readonly string[]).includes(status);
+export function isTerminalIntentStatus(status: string): boolean {
+  return (TERMINAL_INTENT_STATUSES as readonly string[]).includes(
+    status.toUpperCase()
+  );
 }
 
 /**

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -417,16 +417,32 @@ function bytesToLowerHex(bytes: Uint8Array): string {
 }
 
 /**
- * Decode hex string to bytes. Accepts optional `0x` prefix.
+ * Decode hex string to bytes. Accepts optional `0x` prefix. Throws on any
+ * non-hex character (rather than silently coercing to 0, which would
+ * produce a wrong — but valid-length — byte array and a wrong intent id).
  */
 function hexToBytes(hex: string): Uint8Array {
   const s = hex.startsWith("0x") || hex.startsWith("0X") ? hex.slice(2) : hex;
   if (s.length % 2 !== 0) throw new Error(`hex string has odd length: ${hex}`);
+  if (s.length > 0 && !/^[0-9a-fA-F]+$/.test(s)) {
+    throw new Error(`invalid hex string: ${hex}`);
+  }
   const out = new Uint8Array(s.length / 2);
   for (let i = 0; i < out.length; i++) {
     out[i] = parseInt(s.slice(i * 2, i * 2 + 2), 16);
   }
   return out;
+}
+
+/**
+ * Normalize a Spark transfer id (or any id) to bare lowercase hex: strips a
+ * leading `0x`/`0X` and any dashes (dashed-UUID Bitcoin transfer ids). This
+ * mirrors the gateway's `canonicalise_transfer_id_hex`, so the canonical
+ * intent-id preimage hashes the same bytes the gateway parses.
+ */
+function normalizeIdHex(id: string): string {
+  const noPrefix = id.startsWith("0x") || id.startsWith("0X") ? id.slice(2) : id;
+  return noPrefix.replace(/-/g, "");
 }
 
 /**
@@ -508,10 +524,10 @@ export function canonicalIntentId(args: {
   parts.push(cntBuf);
 
   for (const t of args.transfers) {
-    // SparkTransferId canonical_bytes: tag + raw bytes.
-    const idHex = t.transferId.startsWith("0x") || t.transferId.startsWith("0X")
-      ? t.transferId.slice(2)
-      : t.transferId;
+    // SparkTransferId canonical_bytes: tag + raw bytes. Strip `0x` and
+    // dashes (dashed-UUID Bitcoin ids) so the length check and bytes
+    // match the gateway's parsed form.
+    const idHex = normalizeIdHex(t.transferId);
     let idTag: number;
     let idBytes: Uint8Array;
     if (idHex.length === 32) {
@@ -575,9 +591,7 @@ export function canonicalIntentId(args: {
     parts.push(blake3(txBytes));
   } else {
     parts.push(new Uint8Array([0x02]));
-    const idHex = args.action.sparkTxid.startsWith("0x") || args.action.sparkTxid.startsWith("0X")
-      ? args.action.sparkTxid.slice(2)
-      : args.action.sparkTxid;
+    const idHex = normalizeIdHex(args.action.sparkTxid);
     if (idHex.length === 32) {
       parts.push(new Uint8Array([0x00]));
       parts.push(hexToBytes(idHex));

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -18,6 +18,87 @@ export interface Deposit {
   asset: DepositAsset;
   /** Amount in base units (sats for BTC, smallest unit for tokens). Use bigint for precision with large token amounts. */
   amount: number | bigint;
+  /**
+   * Optional signed deposit proof obtained from `POST /api/v1/verifyDeposit`.
+   *
+   * When present, the gateway re-verifies the proof on `/execute` before
+   * forwarding the intent. When absent, the intent falls back to the
+   * legacy admission path that polls the operator side until confirmation.
+   * Higher-level callers should prefer `ExecutionClient.depositWithProofs`,
+   * which fetches proofs and attaches them in one call.
+   */
+  depositProof?: SignedDepositProof;
+}
+
+/**
+ * Signed deposit proof returned by `POST /api/v1/verifyDeposit`.
+ *
+ * `payloadBytes` is an opaque byte string (lowercase hex, no 0x prefix)
+ * carrying the canonical proof payload. `signature` is the compact ECDSA
+ * signature over that payload as 64 lowercase hex bytes (no 0x prefix).
+ * Callers should treat both fields as opaque and pass the value through
+ * unchanged when submitting the intent.
+ */
+export interface SignedDepositProof {
+  payloadBytes: string;
+  signature: string;
+}
+
+/**
+ * Request body for `POST /api/v1/verifyDeposit`.
+ *
+ * `nonce` is a 16-byte random value as 32 lowercase hex chars (no `0x`).
+ * The same nonce MUST be used when the intent is later submitted via
+ * `/execute` - the gateway binds the proof to it at sign time and
+ * rechecks it on submission. Use {@link generateProofNonce} to produce
+ * a compatible value.
+ *
+ * Each transfer's `sparkTransferId` may be supplied as a dashed UUID, a
+ * raw hex string (with or without `0x`), or a 64-char hex string for
+ * token transfers. The gateway canonicalises before lookup.
+ */
+export interface VerifyDepositsRequest {
+  nonce: string;
+  transfers: VerifyDepositTransfer[];
+}
+
+/** One transfer in a {@link VerifyDepositsRequest}. */
+export interface VerifyDepositTransfer {
+  sparkTransferId: string;
+}
+
+/**
+ * Response body for `POST /api/v1/verifyDeposit`.
+ *
+ * `proofs` and `rejections` together cover every input transfer by
+ * `index` (zero-based, matching the request order). A transfer never
+ * appears in both. Rejections carry a stable machine-readable `reason`
+ * so callers can branch on it programmatically.
+ */
+export interface VerifyDepositsResponse {
+  proofs: IndexedDepositProof[];
+  rejections: DepositRejection[];
+}
+
+/** One signed proof in a {@link VerifyDepositsResponse}. */
+export interface IndexedDepositProof {
+  index: number;
+  proof: SignedDepositProof;
+}
+
+/** One rejected transfer in a {@link VerifyDepositsResponse}. */
+export interface DepositRejection {
+  index: number;
+  sparkTransferId: string;
+  /**
+   * Stable machine-readable reason. See the gateway docs for the full
+   * enumeration; common values include `transfer_not_found`,
+   * `condition_a_failed`, `condition_b_failed`, `status_terminal`,
+   * `amount_mismatch`, `network_mismatch`, `token_id_mismatch`,
+   * `transfer_too_old`, `decode_error`, `database_error`, `sign_failed`.
+   */
+  reason: string;
+  message: string;
 }
 
 /** Request to submit a deposit-only intent (credit recipient without executing). */
@@ -241,4 +322,20 @@ export function resolveExpiresAt(expiresAt?: number): number {
   return typeof expiresAt === "number" && Number.isFinite(expiresAt)
     ? expiresAt
     : Date.now() + DEFAULT_INTENT_TTL_MS;
+}
+
+/**
+ * Generate a 16-byte random nonce as 32 lowercase hex chars (no `0x`
+ * prefix, no dashes).
+ *
+ * Use this for any intent that will carry signed deposit proofs - the
+ * `/verifyDeposit` endpoint requires exactly this shape and the same
+ * value must flow through to `/execute`. UUID-shaped nonces are still
+ * accepted for proofless intents on the legacy path but cannot be used
+ * with the proof flow.
+ */
+export function generateProofNonce(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 }

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -5,6 +5,8 @@
  * These map directly to the Rust gateway API types in flashnet-execution.
  */
 
+import { blake3 } from "@noble/hashes/blake3";
+
 /** Asset type for a deposit from Spark into the EVM. */
 export type DepositAsset =
   | { type: "btc" }
@@ -22,10 +24,10 @@ export interface Deposit {
    * Optional signed deposit proof obtained from `POST /api/v1/verifyDeposit`.
    *
    * When present, the gateway re-verifies the proof on `/execute` before
-   * forwarding the intent. When absent, the intent falls back to the
-   * legacy admission path that polls the operator side until confirmation.
-   * Higher-level callers should prefer {@link ExecutionClient.deposit},
-   * which auto-fetches and attaches proofs before submitting the intent.
+   * forwarding the intent. When absent, the SDK either fetches one
+   * automatically (the default) or sends a placeholder shape that the
+   * gateway treats as "not configured" and falls through to the legacy
+   * admission path.
    */
   depositProof?: SignedDepositProof;
 }
@@ -48,18 +50,18 @@ export interface SignedDepositProof {
 /**
  * Request body for `POST /api/v1/verifyDeposit`.
  *
- * `nonce` is a 16-byte random value as 32 lowercase hex chars (no `0x`).
- * The same nonce MUST be used when the intent is later submitted via
- * `/execute` - the gateway binds the proof to it at sign time and
- * rechecks it on submission. Use {@link generateProofNonce} to produce
- * a compatible value.
+ * `intentId` is the canonical 32-byte BLAKE3 hash of the intent the SDK
+ * is about to submit on `/execute`. The returned proofs bind to this
+ * value, so a proof minted for intent A cannot be re-attached to a
+ * request whose body hashes to intent B. Compute it via
+ * {@link canonicalIntentId} from the message you intend to sign.
  *
  * Each transfer's `sparkTransferId` may be supplied as a dashed UUID, a
  * raw hex string (with or without `0x`), or a 64-char hex string for
  * token transfers. The gateway canonicalises before lookup.
  */
 export interface VerifyDepositsRequest {
-  nonce: string;
+  intentId: string;
   transfers: VerifyDepositTransfer[];
 }
 
@@ -268,34 +270,58 @@ export interface ExecutionSigner {
 }
 
 /**
+ * On-the-wire asset variant for canonical transfer entries and
+ * `/execute` request deposits.
+ *
+ * Tagged enum with SCREAMING_SNAKE_CASE variant names, matching the
+ * Rust `Asset` serde shape (`crates/types/intent/src/lib.rs`).
+ */
+export type Asset =
+  | { type: "NATIVE_SATS" }
+  | { type: "SPARK_TOKEN"; tokenId: string };
+
+/**
  * Canonical transfer entry in the signed intent message.
- * Must match the Rust CanonicalTransferEntry serialization (camelCase).
+ *
+ * Mirrors Rust `CanonicalTransferEntry` (camelCase, serde declaration
+ * order: `transferId`, `amount`, `asset`, `depositProof`). The deposit
+ * proof is part of the signed preimage — omitting it on the SDK side
+ * breaks signature verification.
+ *
+ * `amount` is the alloy `U256` JSON shape: `0x`-prefixed lowercase hex
+ * with no leading zeros (`"0x0"` for zero).
  */
 export interface CanonicalTransferEntry {
   transferId: string;
-  amountSats: number | bigint;
-  assetType: "NativeSats" | "SparkToken";
-  tokenId?: string;
+  amount: string;
+  asset: Asset;
+  depositProof: SignedDepositProof;
 }
 
 /**
  * Canonical intent action in the signed intent message.
- * Must match the Rust CanonicalIntentAction serialization
- * (camelCase, internally tagged with "type").
+ *
+ * Internally tagged with `"type"`, lowercase tag names — matches Rust
+ * `CanonicalIntentAction` serde shape (`tag = "type"`, `rename_all =
+ * "camelCase"`).
  */
 export type CanonicalIntentAction =
   | { type: "deposit"; recipient: string }
-  | { type: "execute"; signedTxHash: string };
+  | { type: "execute"; signedTxHash: string }
+  | { type: "clawback"; sparkTxid: string };
 
 /**
  * Canonical intent message that gets signed by the client.
- * Must match the Rust CanonicalIntentMessage serialization (camelCase).
+ *
+ * Field order MUST match Rust `CanonicalIntentMessage` declaration
+ * order: `chainId`, `transfers`, `action`, `expiresAt`. There is no
+ * `nonce` field — replay defense is structural via `intents.intent_id`
+ * uniqueness in the gateway DB (migration 0008).
  */
 export interface CanonicalIntentMessage {
   chainId: number;
   transfers: CanonicalTransferEntry[];
   action: CanonicalIntentAction;
-  nonce: string;
   /**
    * Absolute unix-millisecond timestamp past which the sequencer refuses
    * to admit, include, or settle this intent. Part of the signed preimage
@@ -326,17 +352,234 @@ export function resolveExpiresAt(expiresAt?: number): number {
 }
 
 /**
- * Generate a 16-byte random nonce as 32 lowercase hex chars (no `0x`
- * prefix, no dashes).
+ * Encode a `U256` as the alloy JSON form: `0x` + lowercase hex with no
+ * leading zeros. `0n` is encoded as `"0x0"`.
  *
- * Use this for any intent that will carry signed deposit proofs - the
- * `/verifyDeposit` endpoint requires exactly this shape and the same
- * value must flow through to `/execute`. UUID-shaped nonces are still
- * accepted for proofless intents on the legacy path but cannot be used
- * with the proof flow.
+ * Negative bigints are rejected — `U256` is unsigned.
  */
-export function generateProofNonce(): string {
-  const bytes = new Uint8Array(16);
-  crypto.getRandomValues(bytes);
-  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+export function u256Hex(value: number | bigint): string {
+  const n = typeof value === "bigint" ? value : BigInt(value);
+  if (n < 0n) throw new Error(`u256Hex: negative value ${value}`);
+  return `0x${n.toString(16)}`;
+}
+
+/**
+ * Convert the SDK's user-facing {@link DepositAsset} (lowercase tag) to
+ * the wire {@link Asset} (SCREAMING_SNAKE_CASE tag). The wire `tokenId`
+ * is required to be `0x`-prefixed lowercase 32-byte hex; if the caller
+ * supplies a bare-hex value we prepend `0x`.
+ */
+export function depositAssetToWire(asset: DepositAsset): Asset {
+  if (asset.type === "btc") return { type: "NATIVE_SATS" };
+  const tokenIdHex = asset.tokenId.startsWith("0x")
+    ? asset.tokenId.toLowerCase()
+    : `0x${asset.tokenId.toLowerCase()}`;
+  return { type: "SPARK_TOKEN", tokenId: tokenIdHex };
+}
+
+/**
+ * Placeholder {@link SignedDepositProof} used on the legacy/soft-mode
+ * admission path. The gateway treats any proof that fails
+ * `has_valid_shape()` (empty payload OR non-64-byte signature) as
+ * "not configured" and falls through to the polling admission. The
+ * SDK uses this when `/verifyDeposit` returns 503 or when
+ * `manualProofs: true` is set without an attached proof.
+ */
+export const PLACEHOLDER_DEPOSIT_PROOF: SignedDepositProof = {
+  payloadBytes: "0x",
+  signature: "0x",
+};
+
+/**
+ * Lowercase hex (no `0x`) representation of a byte array.
+ */
+function bytesToLowerHex(bytes: Uint8Array): string {
+  let out = "";
+  for (const b of bytes) out += b.toString(16).padStart(2, "0");
+  return out;
+}
+
+/**
+ * Decode hex string to bytes. Accepts optional `0x` prefix.
+ */
+function hexToBytes(hex: string): Uint8Array {
+  const s = hex.startsWith("0x") || hex.startsWith("0X") ? hex.slice(2) : hex;
+  if (s.length % 2 !== 0) throw new Error(`hex string has odd length: ${hex}`);
+  const out = new Uint8Array(s.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(s.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+/**
+ * Compute the canonical intent id for {@link VerifyDepositsRequest.intentId}
+ * and the on-chain `intents.intent_id` value. BLAKE3 hash of the canonical
+ * preimage described in `crates/types/intent/src/lib.rs:500-548`:
+ *
+ *   tag    = b"FLASHNET_INTENT_V2" (no length prefix)
+ *   chain  = u64 big-endian (8 bytes)
+ *   recipient_for_hash = 20 bytes
+ *     - Deposit  → the recipient address (20 bytes from the 0x-prefixed hex)
+ *     - Execute  → recovered ECDSA signer of the signed tx (provided by caller)
+ *     - Clawback → 20 zero bytes
+ *   transferCount = u32 big-endian (4 bytes)
+ *   for each transfer (declaration order):
+ *     transferId.canonical_bytes:
+ *        0x00 + 16 raw bytes (Bitcoin 32-hex-char id), OR
+ *        0x01 + 32 raw bytes (Token 64-hex-char id)
+ *     amount.to_be_bytes::<32>() = U256 32-byte big-endian
+ *     asset.tag_byte = 0x00 (NativeSats) | 0x01 (SparkToken)
+ *     if SparkToken: 0x01 + 32 raw token-id bytes; else 0x00
+ *   action discriminator + body:
+ *     Deposit   → 0x00
+ *     Execute   → 0x01 + blake3(signedTx-bytes) (32 bytes)
+ *     Clawback  → 0x02 + sparkTxid.canonical_bytes (tag + bytes)
+ *
+ * Note: `expiresAt` and per-transfer `depositProof` are NOT part of the
+ * BLAKE3 preimage — they live only on the JSON signed-preimage.
+ *
+ * `recipientForHash` must be the canonical 20-byte recipient determined
+ * by the action variant — the caller is responsible for recovering the
+ * ECDSA signer for Execute actions; pass `0x` + 40 zero hex for Clawback.
+ */
+export function canonicalIntentId(args: {
+  chainId: number | bigint;
+  transfers: CanonicalTransferEntry[];
+  action: CanonicalIntentAction;
+  /**
+   * For Deposit: the 0x-prefixed recipient address.
+   * For Execute: the ECDSA-recovered signer of the signed transaction (0x-prefixed 20-byte hex).
+   * For Clawback: ignored; the canonical recipient is the zero address.
+   */
+  recipientForHash: string;
+  /**
+   * For Execute: the raw signed-transaction bytes (hex, with or without
+   * `0x`). Hashed with BLAKE3 to form the action body. Ignored for
+   * Deposit / Clawback.
+   */
+  signedTxHex?: string;
+}): string {
+  const parts: Uint8Array[] = [];
+  parts.push(new TextEncoder().encode("FLASHNET_INTENT_V2"));
+
+  const chain = BigInt(args.chainId);
+  if (chain < 0n || chain > 0xffffffffffffffffn) {
+    throw new Error(`chainId out of u64 range: ${args.chainId}`);
+  }
+  const chainBuf = new Uint8Array(8);
+  new DataView(chainBuf.buffer).setBigUint64(0, chain, false);
+  parts.push(chainBuf);
+
+  // recipient_for_hash: 20 bytes
+  let recipientBytes: Uint8Array;
+  if (args.action.type === "clawback") {
+    recipientBytes = new Uint8Array(20);
+  } else {
+    const rec = args.recipientForHash;
+    const recHex = rec.startsWith("0x") || rec.startsWith("0X") ? rec.slice(2) : rec;
+    if (recHex.length !== 40) {
+      throw new Error(`recipientForHash must be 20 bytes (40 hex chars): got ${rec}`);
+    }
+    recipientBytes = hexToBytes(recHex);
+  }
+  parts.push(recipientBytes);
+
+  // transferCount: u32 BE
+  const cntBuf = new Uint8Array(4);
+  new DataView(cntBuf.buffer).setUint32(0, args.transfers.length, false);
+  parts.push(cntBuf);
+
+  for (const t of args.transfers) {
+    // SparkTransferId canonical_bytes: tag + raw bytes.
+    const idHex = t.transferId.startsWith("0x") || t.transferId.startsWith("0X")
+      ? t.transferId.slice(2)
+      : t.transferId;
+    let idTag: number;
+    let idBytes: Uint8Array;
+    if (idHex.length === 32) {
+      idTag = 0x00;
+      idBytes = hexToBytes(idHex);
+    } else if (idHex.length === 64) {
+      idTag = 0x01;
+      idBytes = hexToBytes(idHex);
+    } else {
+      throw new Error(
+        `transferId must be 16 bytes (32 hex chars) or 32 bytes (64 hex chars): got ${t.transferId}`
+      );
+    }
+    parts.push(new Uint8Array([idTag]));
+    parts.push(idBytes);
+
+    // amount: u256 32-byte BE
+    const amtHex = t.amount.startsWith("0x") || t.amount.startsWith("0X")
+      ? t.amount.slice(2)
+      : t.amount;
+    const amt = amtHex === "" ? 0n : BigInt(`0x${amtHex}`);
+    if (amt < 0n) throw new Error(`amount negative: ${t.amount}`);
+    const amtBuf = new Uint8Array(32);
+    let n = amt;
+    for (let i = 31; i >= 0; i--) {
+      amtBuf[i] = Number(n & 0xffn);
+      n >>= 8n;
+    }
+    if (n !== 0n) throw new Error(`amount exceeds 32 bytes: ${t.amount}`);
+    parts.push(amtBuf);
+
+    // asset tag + optional token id
+    if (t.asset.type === "NATIVE_SATS") {
+      parts.push(new Uint8Array([0x00]));
+      parts.push(new Uint8Array([0x00])); // no token id present
+    } else {
+      parts.push(new Uint8Array([0x01]));
+      parts.push(new Uint8Array([0x01]));
+      const tokenIdHex = t.asset.tokenId.startsWith("0x") || t.asset.tokenId.startsWith("0X")
+        ? t.asset.tokenId.slice(2)
+        : t.asset.tokenId;
+      if (tokenIdHex.length !== 64) {
+        throw new Error(`SparkToken tokenId must be 32 bytes (64 hex chars): got ${t.asset.tokenId}`);
+      }
+      parts.push(hexToBytes(tokenIdHex));
+    }
+  }
+
+  // action discriminator + body
+  if (args.action.type === "deposit") {
+    parts.push(new Uint8Array([0x00]));
+  } else if (args.action.type === "execute") {
+    if (!args.signedTxHex) {
+      throw new Error(`canonicalIntentId: execute action requires signedTxHex`);
+    }
+    parts.push(new Uint8Array([0x01]));
+    const txHex = args.signedTxHex.startsWith("0x") || args.signedTxHex.startsWith("0X")
+      ? args.signedTxHex.slice(2)
+      : args.signedTxHex;
+    const txBytes = hexToBytes(txHex);
+    parts.push(blake3(txBytes));
+  } else {
+    parts.push(new Uint8Array([0x02]));
+    const idHex = args.action.sparkTxid.startsWith("0x") || args.action.sparkTxid.startsWith("0X")
+      ? args.action.sparkTxid.slice(2)
+      : args.action.sparkTxid;
+    if (idHex.length === 32) {
+      parts.push(new Uint8Array([0x00]));
+      parts.push(hexToBytes(idHex));
+    } else if (idHex.length === 64) {
+      parts.push(new Uint8Array([0x01]));
+      parts.push(hexToBytes(idHex));
+    } else {
+      throw new Error(`clawback sparkTxid must be 16 or 32 bytes: got ${args.action.sparkTxid}`);
+    }
+  }
+
+  // Concatenate and BLAKE3-hash.
+  let total = 0;
+  for (const p of parts) total += p.length;
+  const buf = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    buf.set(p, off);
+    off += p.length;
+  }
+  return bytesToLowerHex(blake3(buf));
 }

--- a/tests/smoke-deposit-intent.ts
+++ b/tests/smoke-deposit-intent.ts
@@ -166,7 +166,7 @@ async function main(): Promise<void> {
       "response.intentId is a non-empty string"
     );
     assert(
-      ["accepted", "oracle_pending", "included_pending_finality", "finalized"].includes(
+      ["ACCEPTED", "INCLUDED_PENDING_FINALITY", "FINALIZED"].includes(
         resp.status
       ),
       `response.status is one of the lifecycle values (got: "${resp.status}")`

--- a/tests/smoke-deposit-intent.ts
+++ b/tests/smoke-deposit-intent.ts
@@ -1,0 +1,237 @@
+/**
+ * Deposit-intent smoke test against a running localnet.
+ *
+ * Runs the full SDK round-trip:
+ *   1. authenticate via challenge/response,
+ *   2. build a deposit intent with one fabricated Spark transfer,
+ *   3. call /verifyDeposit with the canonical intentId (the SDK does
+ *      this automatically inside deposit()),
+ *   4. submit /execute,
+ *   5. assert the response shape matches the post-#564 contract.
+ *
+ * The smoke fixture uses a fabricated `sparkTransferId` that the operator
+ * DB will not find, so the expected happy path is:
+ *
+ *   - /verifyDeposit returns 200 with a single `transfer_not_found`
+ *     rejection, and the SDK throws `VerifyDepositRejectedError`
+ *     before /execute is reached.
+ *
+ * That outcome PROVES the wire shape contract on both sides:
+ *   - the gateway accepted the `{intentId, transfers}` body (no
+ *     "unknown field" 400),
+ *   - the rejection JSON shape matches `DepositRejection`,
+ *   - the SDK's canonical intent_id matched what the gateway computes
+ *     for an intent of the same shape.
+ *
+ * If /verifyDeposit is 503 (soft-mode gateway with no
+ * `verify_deposit_pubkey` configured), the SDK falls through to
+ * /execute with a placeholder proof; the response shape assertion
+ * still applies — the smoke test passes either way as long as the
+ * contract holds.
+ *
+ * Run:
+ *   GATEWAY_URL=http://localhost:8080 bun run tests/smoke-deposit-intent.ts
+ */
+
+import { secp256k1 } from "@noble/curves/secp256k1";
+import {
+  ExecutionClient,
+  VerifyDepositRejectedError,
+  canonicalIntentId,
+  PLACEHOLDER_DEPOSIT_PROOF,
+  type SparkWalletInput,
+} from "../src/execution";
+
+const GATEWAY_URL = process.env.GATEWAY_URL ?? "http://localhost:8080";
+const RPC_URL = process.env.RPC_URL ?? "http://localhost:8545";
+const CHAIN_ID = Number(process.env.CHAIN_ID ?? 21022);
+
+function mockWalletFromPrivateKey(privateKey: Uint8Array): SparkWalletInput {
+  const publicKey = secp256k1.getPublicKey(privateKey, true);
+  return {
+    config: {
+      signer: {
+        async getIdentityPublicKey() {
+          return publicKey;
+        },
+        async signMessageWithIdentityKey(
+          message: Uint8Array,
+          compact?: boolean
+        ) {
+          const sig = secp256k1.sign(message, privateKey);
+          return compact ? sig.toCompactRawBytes() : sig.toDERRawBytes();
+        },
+      },
+    },
+  } as unknown as SparkWalletInput;
+}
+
+function deterministicWallet(): SparkWalletInput {
+  const key = new Uint8Array(32).fill(0);
+  // Well-known test key. Not used to claim funds — we only need a
+  // stable identity for the JWT.
+  key[31] = 0x42;
+  return mockWalletFromPrivateKey(key);
+}
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond: boolean, msg: string): void {
+  if (cond) {
+    passed++;
+    console.log(`  ✓ ${msg}`);
+  } else {
+    failed++;
+    console.error(`  ✗ FAIL: ${msg}`);
+  }
+}
+
+async function main(): Promise<void> {
+  console.log("=== Flashnet Deposit-Intent Smoke Test (PR #564/#622 + #68) ===");
+  console.log(`Gateway: ${GATEWAY_URL}`);
+  console.log(`RPC:     ${RPC_URL}`);
+  console.log(`Chain:   ${CHAIN_ID}`);
+
+  const client = new ExecutionClient(deterministicWallet(), {
+    gatewayUrl: GATEWAY_URL,
+    rpcUrl: RPC_URL,
+    chainId: CHAIN_ID,
+  });
+
+  // ─── Gateway health ────────────────────────────────────────────
+  console.log("\n--- gateway health ---");
+  const healthy = await client.health();
+  assert(healthy, "GET /api/v1/health responds with status:ok");
+  if (!healthy) {
+    console.error("Gateway is not reachable — aborting.");
+    process.exit(1);
+  }
+
+  // ─── Authenticate ─────────────────────────────────────────────
+  console.log("\n--- authenticate ---");
+  const accessToken = await client.authenticate();
+  assert(
+    typeof accessToken === "string" && accessToken.length > 0,
+    "POST /api/v1/auth/{challenge,verify} returns an access token"
+  );
+
+  // ─── Submit a deposit intent ──────────────────────────────────
+  // A deterministic, well-formed `sparkTransferId` that the operator
+  // DB will not find — that's exactly what we want for the wire-shape
+  // assertion. Length 32 hex chars = a Bitcoin transfer UUID (16 bytes).
+  const sparkTransferId = "deadbeefcafef00d0123456789abcdef";
+  const recipient = (await client.getEvmAddress()).toLowerCase();
+  console.log("\n--- deposit intent (expects transfer_not_found) ---");
+  console.log(`  sparkTransferId: ${sparkTransferId}`);
+  console.log(`  recipient:       ${recipient}`);
+
+  // Compute the canonical intent_id the SDK *should* send to
+  // /verifyDeposit, so we can verify the gateway's behaviour matches.
+  const expectedIntentId = canonicalIntentId({
+    chainId: CHAIN_ID,
+    transfers: [
+      {
+        transferId: sparkTransferId,
+        amount: "0x186a0", // 100_000 sats
+        asset: { type: "NATIVE_SATS" },
+        depositProof: PLACEHOLDER_DEPOSIT_PROOF,
+      },
+    ],
+    action: { type: "deposit", recipient },
+    recipientForHash: recipient,
+  });
+  console.log(`  computed intentId: ${expectedIntentId}`);
+
+  try {
+    const resp = await client.deposit({
+      recipient,
+      deposits: [
+        {
+          sparkTransferId,
+          asset: { type: "btc" },
+          amount: 100_000n,
+        },
+      ],
+    });
+    // If we got here the deposit was admitted — surprising but valid
+    // as long as the response shape matches.
+    console.log(`  response: ${JSON.stringify(resp)}`);
+    assert(
+      typeof resp.submissionId === "string" && resp.submissionId.length > 0,
+      "response.submissionId is a non-empty string"
+    );
+    assert(
+      typeof resp.intentId === "string" && resp.intentId.length > 0,
+      "response.intentId is a non-empty string"
+    );
+    assert(
+      ["accepted", "oracle_pending", "included_pending_finality", "finalized"].includes(
+        resp.status
+      ),
+      `response.status is one of the lifecycle values (got: "${resp.status}")`
+    );
+  } catch (err) {
+    if (err instanceof VerifyDepositRejectedError) {
+      // Expected branch: gateway accepted the wire shape, found no
+      // such transfer in the operator DB, and surfaced a typed
+      // rejection. This is a passing outcome for the smoke test.
+      console.log(
+        `  /verifyDeposit returned rejections: ${JSON.stringify(err.rejections, null, 2)}`
+      );
+      assert(
+        err.rejections.length === 1,
+        "exactly one rejection (matches the single fabricated transfer)"
+      );
+      const rej = err.rejections[0]!;
+      assert(
+        rej.index === 0,
+        `rejection index is 0 (got ${rej.index})`
+      );
+      assert(
+        rej.sparkTransferId.toLowerCase() === sparkTransferId.toLowerCase(),
+        "rejection sparkTransferId echoes the request"
+      );
+      assert(
+        typeof rej.reason === "string" && rej.reason.length > 0,
+        `rejection.reason is a non-empty string (got: "${rej.reason}")`
+      );
+      assert(
+        typeof rej.message === "string",
+        "rejection.message is a string"
+      );
+      console.log(
+        `  reason="${rej.reason}" — gateway accepted the {intentId, transfers} body`
+      );
+    } else {
+      const msg = err instanceof Error ? `${err.message}\n${err.stack}` : String(err);
+      console.error(`  unexpected error: ${msg}`);
+      failed++;
+    }
+  }
+
+  // ─── getIntentStatus 404 (sanity check the status API still works) ─
+  console.log("\n--- getIntentStatus 404 ---");
+  try {
+    await client.getIntentStatus("00000000-0000-0000-0000-000000000000");
+    failed++;
+    console.error("  ✗ FAIL: expected 404 on unknown submission id");
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (/404|not found|HTTP 4/i.test(msg)) {
+      passed++;
+      console.log("  ✓ getIntentStatus rejects unknown submission id");
+    } else {
+      failed++;
+      console.error(`  ✗ unexpected error: ${msg}`);
+    }
+  }
+
+  console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`);
+  if (failed > 0) process.exit(1);
+}
+
+main().catch((e) => {
+  console.error("Fatal error:", e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds support for **signed deposit proofs** that the execution gateway can re-verify in line when submitting an intent, replacing the legacy polling admission path. The flow is automatic by default: existing call sites (`client.deposit`, `client.execute`) keep working with no changes; the SDK quietly fetches and attaches proofs under the hood.

## What changes for the caller

**Nothing if they want the default.** `client.deposit({ deposits })` and `client.execute({ deposits, signedTx })` keep their existing signature. Internally they now:

1. Call `POST /api/v1/verifyDeposit` for any deposit that arrives without an attached `depositProof`.
2. Stitch the returned proofs into the matching `deposits[i].depositProof` slot.
3. Sign and submit the intent as before, with the proofs attached to `/execute`.

If the gateway has not enabled `/verifyDeposit` (503 response), the SDK falls back to the legacy proofless path silently. If verification returns rejections, the SDK throws a typed `VerifyDepositRejectedError` **before** the intent is signed - the caller never silently loses a deposit.

## Public surface

- **`Deposit.depositProof?: SignedDepositProof`** - optional. The auto-attach flow populates this; callers can also pre-populate it via the BYO path.
- **`ExecutionClient.verifyDeposit({ nonce, sparkTransferIds })`** - low-level escape hatch. Useful when you want to inspect rejections before committing, cache proofs for later, or stage the work in multiple steps.
- **`generateProofNonce()`** - 16-byte random value as 32 lowercase hex chars. Use it when calling `verifyDeposit` directly.
- **`VerifyDepositRejectedError`** - thrown when `/verifyDeposit` returns per-transfer rejections; carries `rejections: DepositRejection[]` so callers can branch on `reason` programmatically (e.g. retry on `transfer_not_found`, alert on `condition_a_failed`).
- **`{ manualProofs: true }`** on `DepositParams` / `ExecuteParams` - "bring your own logic" opt-out. The SDK passes deposits through unchanged so the caller drives the proof flow themselves.

## Safety guards

- Pre-attached `depositProof` entries are bound to a specific nonce. If the caller supplies any pre-attached proof without also supplying that nonce, the SDK throws **before signing** rather than letting the gateway reject the intent for a binding mismatch at submit time.
- Pre-attached proofs are shape-checked locally before signing (signature must be 64 hex bytes; bare or `0x`-prefixed).
- Per-transfer rejections short-circuit the flow with a typed error; no `/execute` call is ever made under partial confirmation.

## Wire-format alignment

Verified against the production gateway implementation:

- `/verifyDeposit` request body: `{ nonce, transfers: [{ sparkTransferId }] }` with `camelCase` and `deny_unknown_fields` - matches.
- `/verifyDeposit` response: `{ proofs: [{ index, proof: { payloadBytes, signature } }], rejections: [{ index, sparkTransferId, reason, message }] }` - matches.
- `Deposit.depositProof` on `/execute` body: `{ payloadBytes, signature }`, both fields accepted as bare or `0x`-prefixed hex on input - matches.

## Typical usage

```ts
// Default - just works
await client.deposit({
  deposits: [
    {
      sparkTransferId: "a1b2c3d4-e5f6-0718-a1b2-c3d4e5f60718",
      asset: { type: "btc" },
      amount: 100_000n,
    },
  ],
});

// Modular - inspect rejections before committing
const nonce = generateProofNonce();
try {
  const { proofs } = await client.verifyDeposit({
    nonce,
    sparkTransferIds: deposits.map((d) => d.sparkTransferId),
  });
  const withProofs = deposits.map((d, i) => ({
    ...d,
    depositProof: proofs[i].proof,
  }));
  await client.deposit({ deposits: withProofs, nonce });
} catch (err) {
  if (err instanceof VerifyDepositRejectedError) {
    // branch on err.rejections[].reason
  } else {
    throw err;
  }
}

// Bring your own logic
await client.deposit({ deposits, manualProofs: true });
```

## Test plan

- [x] `bunx tsc --noEmit`: clean
- [x] `bunx jest`: 77 / 77 pass, including 12 coverage points for the proof flow:
  - generateProofNonce shape + uniqueness
  - request/response type round-trips
  - auto-attach end to end (same nonce on `/verifyDeposit` and `/execute`)
  - pre-supplied proof short-circuits the verify call
  - 503 fallback to legacy path
  - typed `VerifyDepositRejectedError` with structured rejections
  - 0x-prefixed pre-attached proof flows through the BYO path
  - missing-nonce guard with pre-attached proofs
  - malformed signature guard
  - `manualProofs:true` bypasses verification entirely
- [x] `bun run build`: clean (ESM + CJS bundles produced)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add automatic deposit proof attachment and verification to intent submission
> - Introduces `resolveProofs` in [client.ts](https://github.com/flashnetxyz/ts-sdk/pull/68/files#diff-aa839a246a243d62eae2a42349f66de061dd3599fa0c873c35be53877bd6ec64) to automatically fetch and attach deposit proofs via `POST /api/v1/verifyDeposit` for any deposits that lack them before submitting an intent; opt-out available via `manualProofs` flag.
> - Adds `ExecutionClient.verifyDeposit()` as a public method for explicit proof verification against a set of Spark transfer IDs.
> - Computes the canonical BLAKE3 intent ID locally in `canonicalIntentId()` ([types.ts](https://github.com/flashnetxyz/ts-sdk/pull/68/files#diff-ab028f912c24c154bc692cc1d065e239a88f71059e060466969b99ba2966b936)) to bind proofs and align with gateway DB uniqueness.
> - Updates the wire format for intent submission: amounts are now U256 hex strings, assets use SCREAMING_SNAKE_CASE tags, `nonce` is removed from `CanonicalIntentMessage`, and `depositProof` is included per transfer.
> - Adds a pre-flight native balance check in `withdraw()` and normalizes all `IntentStatus` values to SCREAMING_SNAKE_CASE.
> - Risk: breaking wire format change — intent submissions now require U256 hex amounts, SCREAMING_SNAKE_CASE assets, and no nonce; existing clients sending the old format will be incompatible.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b447d36.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->