### PR TITLE
test(execution): guard NetworkInfo against trading-stack addresses

### DIFF
--- a/src/execution/network-info-address-invariant.spec.ts
+++ b/src/execution/network-info-address-invariant.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * Guardrail tests — trading-stack addresses stay out of `/network/info`
+ * (flashnet-execution#554).
+ *
+ * The gateway's network-info surface publishes execution concerns only. The
+ * Conductor / WBTC / Uniswap V3 factory / NonfungiblePositionManager /
+ * Permit2 addresses move on the trading stack's own release cadence and live
+ * in `AMMConfig` / `AMM_ENVIRONMENT_CONFIGS`, never on `NetworkInfo`.
+ *
+ * The *compile-time* enforcement lives next to the type definitions in
+ * `types.ts` (the `AssertTrue<HasNoTradingAddress<...>>` aliases) and fails
+ * `tsc --noEmit` if a forbidden field is ever added. These runtime tests are
+ * the executable counterpart: they pin the wire shape the gateway is expected
+ * to return and assert no trading-stack key has crept in at any level.
+ */
+
+import { secp256k1 } from "@noble/curves/secp256k1";
+import { ExecutionClient } from "./client";
+import type { SparkWalletInput } from "./spark-evm-account";
+import type {
+  ExecutionNetworkInfo,
+  NetworkInfo,
+  SparkNetworkInfo,
+} from "./types";
+
+/** Every trading-stack address field that must never appear on NetworkInfo. */
+const FORBIDDEN_TRADING_ADDRESS_KEYS = [
+  "conductorAddress",
+  "wbtcAddress",
+  "factoryAddress",
+  "positionManagerAddress",
+  "permit2Address",
+  "uniswapFactoryAddress",
+] as const;
+
+/**
+ * Canonical `/api/v1/network/info` payload. Mirrors the fixture in
+ * `network-info.spec.ts` and the Rust gateway response shape. Typed as
+ * {@link NetworkInfo} so a forbidden excess key here is *also* a compile
+ * error, not just a runtime assertion failure.
+ */
+const NETWORK_INFO: NetworkInfo = {
+  spark: {
+    depositAddress: "sparkrt1pgsstest",
+    network: "REGTEST",
+  },
+  execution: {
+    contractAddress: "0x1e2861ce58eaa89260226b5704416b9a20589d47",
+    chainId: 21022,
+  },
+  paused: false,
+  minDepositSats: 1000,
+};
+
+const TEST_KEY = new Uint8Array(32);
+TEST_KEY[31] = 1;
+
+function mockWallet(): SparkWalletInput {
+  return {
+    config: {
+      signer: {
+        getIdentityPublicKey: async () =>
+          secp256k1.getPublicKey(TEST_KEY, true),
+        signMessageWithIdentityKey: async () => new Uint8Array(64),
+      },
+    },
+  } as unknown as SparkWalletInput;
+}
+
+function keysOf(obj: object): string[] {
+  return Object.keys(obj);
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("NetworkInfo trading-address guardrail (flashnet-execution#554)", () => {
+  it("exposes only execution-discovery concerns at the top level", () => {
+    expect(keysOf(NETWORK_INFO).sort()).toEqual(
+      ["execution", "minDepositSats", "paused", "spark"].sort()
+    );
+  });
+
+  it("SparkNetworkInfo carries only depositAddress + network", () => {
+    const spark: SparkNetworkInfo = NETWORK_INFO.spark;
+    expect(keysOf(spark).sort()).toEqual(["depositAddress", "network"].sort());
+  });
+
+  it("ExecutionNetworkInfo carries only contractAddress + chainId", () => {
+    const execution: ExecutionNetworkInfo = NETWORK_INFO.execution;
+    expect(keysOf(execution).sort()).toEqual(
+      ["chainId", "contractAddress"].sort()
+    );
+  });
+
+  it("carries no trading-stack address field at any level", () => {
+    const allKeys = [
+      ...keysOf(NETWORK_INFO),
+      ...keysOf(NETWORK_INFO.spark),
+      ...keysOf(NETWORK_INFO.execution),
+    ];
+    for (const forbidden of FORBIDDEN_TRADING_ADDRESS_KEYS) {
+      expect(allKeys).not.toContain(forbidden);
+    }
+  });
+
+  it("getNetworkInfo() never reads a trading-stack address off the response", async () => {
+    // The gateway could, in principle, start returning extra fields. The SDK
+    // must not grow a code path that reads a trading address off the result.
+    // We stub a deliberately *polluted* response and assert the SDK still
+    // returns it verbatim (no projection) — the contract is "ignore extras",
+    // enforced for the typed surface by the compile-time guard in types.ts.
+    const polluted = {
+      ...NETWORK_INFO,
+      execution: {
+        ...NETWORK_INFO.execution,
+        conductorAddress: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+      },
+    };
+    global.fetch = jest.fn(
+      async () =>
+        new Response(JSON.stringify(polluted), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+    ) as unknown as typeof fetch;
+
+    const client = new ExecutionClient(mockWallet(), {
+      gatewayUrl: "http://localhost:8080",
+      rpcUrl: "http://localhost:8545",
+      chainId: 21022,
+    });
+    const info = await client.getNetworkInfo();
+
+    // The typed accessor exposes only the documented execution fields. Reading
+    // a trading address would require an `as any` escape hatch — exactly what
+    // the guardrail forbids. Assert the documented fields are intact.
+    expect(info.execution.contractAddress).toBe(
+      NETWORK_INFO.execution.contractAddress
+    );
+    expect(info.execution.chainId).toBe(NETWORK_INFO.execution.chainId);
+    expect(info.spark.depositAddress).toBe(NETWORK_INFO.spark.depositAddress);
+  });
+});

--- a/src/execution/network-info-address-invariant.spec.ts
+++ b/src/execution/network-info-address-invariant.spec.ts
@@ -1,17 +1,10 @@
 /**
- * Guardrail tests — trading-stack addresses stay out of `/network/info`
- * (flashnet-execution#554).
+ * Guardrail tests: trading-stack addresses stay off `/network/info`.
  *
- * The gateway's network-info surface publishes execution concerns only. The
- * Conductor / WBTC / Uniswap V3 factory / NonfungiblePositionManager /
- * Permit2 addresses move on the trading stack's own release cadence and live
- * in `AMMConfig` / `AMM_ENVIRONMENT_CONFIGS`, never on `NetworkInfo`.
- *
- * The *compile-time* enforcement lives next to the type definitions in
- * `types.ts` (the `AssertTrue<HasNoTradingAddress<...>>` aliases) and fails
- * `tsc --noEmit` if a forbidden field is ever added. These runtime tests are
- * the executable counterpart: they pin the wire shape the gateway is expected
- * to return and assert no trading-stack key has crept in at any level.
+ * Compile-time enforcement lives in `types.ts`; these runtime tests are the
+ * executable counterpart, pinning the expected wire shape and asserting no
+ * trading-stack key (Conductor / WBTC / factory / NPM / Permit2) appears at
+ * any level.
  */
 
 import { secp256k1 } from "@noble/curves/secp256k1";
@@ -75,7 +68,7 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
-describe("NetworkInfo trading-address guardrail (flashnet-execution#554)", () => {
+describe("NetworkInfo trading-address guardrail", () => {
   it("exposes only execution-discovery concerns at the top level", () => {
     expect(keysOf(NETWORK_INFO).sort()).toEqual(
       ["execution", "minDepositSats", "paused", "spark"].sort()
@@ -106,15 +99,11 @@ describe("NetworkInfo trading-address guardrail (flashnet-execution#554)", () =>
   });
 
   it("returns the gateway response verbatim — trading addresses stay off the typed surface (compile-time enforced)", async () => {
-    // Honest scope: `getNetworkInfo()` does NOT strip unknown fields — it
-    // returns the parsed JSON verbatim, so a polluted `conductorAddress`
-    // physically survives at runtime. The guarantee this test documents is the
-    // *contract*: the SDK never grows a code path that reads a trading address
-    // off the result, and the typed surface makes such a read impossible
-    // without an `as`-cast escape hatch. That typed-surface guarantee is
-    // enforced at compile time by the `AssertTrue<HasNoTradingAddress<...>>`
-    // aliases in types.ts; here we just pin that the documented fields survive
-    // an unexpected, extra-field response unchanged.
+    // `getNetworkInfo()` returns the parsed JSON verbatim — it does not strip
+    // unknown fields, so a polluted `conductorAddress` survives at runtime.
+    // The real guarantee is the typed surface (enforced at compile time in
+    // types.ts): reading a trading address requires an `as`-cast. Here we just
+    // pin that the documented fields survive an extra-field response unchanged.
     const polluted = {
       ...NETWORK_INFO,
       execution: {

--- a/src/execution/network-info-address-invariant.spec.ts
+++ b/src/execution/network-info-address-invariant.spec.ts
@@ -105,12 +105,16 @@ describe("NetworkInfo trading-address guardrail (flashnet-execution#554)", () =>
     }
   });
 
-  it("getNetworkInfo() never reads a trading-stack address off the response", async () => {
-    // The gateway could, in principle, start returning extra fields. The SDK
-    // must not grow a code path that reads a trading address off the result.
-    // We stub a deliberately *polluted* response and assert the SDK still
-    // returns it verbatim (no projection) — the contract is "ignore extras",
-    // enforced for the typed surface by the compile-time guard in types.ts.
+  it("returns the gateway response verbatim — trading addresses stay off the typed surface (compile-time enforced)", async () => {
+    // Honest scope: `getNetworkInfo()` does NOT strip unknown fields — it
+    // returns the parsed JSON verbatim, so a polluted `conductorAddress`
+    // physically survives at runtime. The guarantee this test documents is the
+    // *contract*: the SDK never grows a code path that reads a trading address
+    // off the result, and the typed surface makes such a read impossible
+    // without an `as`-cast escape hatch. That typed-surface guarantee is
+    // enforced at compile time by the `AssertTrue<HasNoTradingAddress<...>>`
+    // aliases in types.ts; here we just pin that the documented fields survive
+    // an unexpected, extra-field response unchanged.
     const polluted = {
       ...NETWORK_INFO,
       execution: {

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -231,6 +231,11 @@ export interface IntentStatusResponse {
  * and where on-chain transactions go (execution side). Clients call
  * `ExecutionClient.getNetworkInfo()` once per session (memoized, 60s TTL)
  * and read fields here instead of hard-coding them in environment config.
+ *
+ * Trading-stack contract addresses are intentionally absent from this
+ * surface — they live in `AMMConfig` / `AMM_ENVIRONMENT_CONFIGS`. The
+ * compile-time guardrail just below {@link ExecutionNetworkInfo} enforces
+ * this (flashnet-execution#554).
  */
 export interface NetworkInfo {
   spark: SparkNetworkInfo;
@@ -263,6 +268,58 @@ export interface ExecutionNetworkInfo {
   /** Execution-chain chain id. */
   chainId: number;
 }
+
+/**
+ * Guardrail — trading-stack addresses stay out of `/network/info`
+ * (flashnet-execution#554).
+ *
+ * `/api/v1/network/info` publishes *execution* concerns only: the Spark
+ * deposit address, the SparkGateway/bridge contract, the chain id, the
+ * paused flag, and the advisory minimum deposit. Trading-stack contract
+ * addresses — Conductor, WBTC, the Uniswap V3 factory, the
+ * NonfungiblePositionManager, and Permit2 — move on the trading stack's own
+ * release cadence, independent of the gateway lifecycle. They live in
+ * `AMMConfig` / `AMM_ENVIRONMENT_CONFIGS` keyed by `ClientEnvironment`, never
+ * on this typed surface. If the gateway ever returns one, the SDK ignores it
+ * instead of projecting it here.
+ *
+ * The aliases below fail `tsc --noEmit` (and thus `build`) if a trading-stack
+ * address field is ever added to {@link NetworkInfo},
+ * {@link ExecutionNetworkInfo}, or {@link SparkNetworkInfo}. They are erased
+ * at runtime. The runtime counterpart lives in
+ * `network-info-address-invariant.spec.ts`.
+ */
+type ForbiddenTradingAddressKey =
+  | "conductorAddress"
+  | "wbtcAddress"
+  | "factoryAddress"
+  | "positionManagerAddress"
+  | "permit2Address"
+  | "uniswapFactoryAddress";
+
+/** `true` when `T` carries no forbidden trading-stack address key. */
+type HasNoTradingAddress<T> = Extract<
+  keyof T,
+  ForbiddenTradingAddressKey
+> extends never
+  ? true
+  : false;
+
+/** Resolves only when `T` is exactly `true`; any other input is a compile error. */
+type AssertTrue<T extends true> = T;
+
+// Adding e.g. `conductorAddress` to any of these interfaces flips its
+// `HasNoTradingAddress` result to `false`, violating the `AssertTrue`
+// constraint and failing the build. See the doc block above.
+type _NetworkInfoHasNoTradingAddress = AssertTrue<
+  HasNoTradingAddress<NetworkInfo>
+>;
+type _ExecutionNetworkInfoHasNoTradingAddress = AssertTrue<
+  HasNoTradingAddress<ExecutionNetworkInfo>
+>;
+type _SparkNetworkInfoHasNoTradingAddress = AssertTrue<
+  HasNoTradingAddress<SparkNetworkInfo>
+>;
 
 /**
  * Signer interface for the execution client.

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -232,10 +232,9 @@ export interface IntentStatusResponse {
  * `ExecutionClient.getNetworkInfo()` once per session (memoized, 60s TTL)
  * and read fields here instead of hard-coding them in environment config.
  *
- * Trading-stack contract addresses are intentionally absent from this
- * surface — they live in `AMMConfig` / `AMM_ENVIRONMENT_CONFIGS`. The
- * compile-time guardrail just below {@link ExecutionNetworkInfo} enforces
- * this (flashnet-execution#554).
+ * Trading-stack contract addresses are intentionally absent — they live in
+ * `AMMConfig`, and the compile-time guardrail below
+ * {@link ExecutionNetworkInfo} keeps them off this surface.
  */
 export interface NetworkInfo {
   spark: SparkNetworkInfo;
@@ -270,27 +269,18 @@ export interface ExecutionNetworkInfo {
 }
 
 /**
- * Guardrail — trading-stack addresses stay out of `/network/info`
- * (flashnet-execution#554).
+ * Guardrail: trading-stack addresses stay off `/network/info`.
  *
- * `/api/v1/network/info` publishes *execution* concerns only: the Spark
- * deposit address, the SparkGateway/bridge contract, the chain id, the
- * paused flag, and the advisory minimum deposit. Trading-stack contract
- * addresses — Conductor, WBTC, the Uniswap V3 factory, the
- * NonfungiblePositionManager, and Permit2 — move on the trading stack's own
- * release cadence, independent of the gateway lifecycle. They live in
- * `AMMConfig` / `AMM_ENVIRONMENT_CONFIGS` keyed by `ClientEnvironment`, never
- * on this typed surface. If the gateway ever returns one, the SDK ignores it
- * instead of projecting it here.
- *
- * The aliases below fail `tsc --noEmit` (and thus `build`) if a trading-stack
- * address field is ever added to {@link NetworkInfo},
- * {@link ExecutionNetworkInfo}, or {@link SparkNetworkInfo}. They are erased
- * at runtime. The runtime counterpart lives in
- * `network-info-address-invariant.spec.ts`.
+ * The gateway publishes execution concerns only (Spark deposit address, bridge
+ * contract, chain id, paused flag, min deposit). Conductor / WBTC / factory /
+ * NonfungiblePositionManager / Permit2 addresses live in `AMMConfig`, because
+ * they move on the trading stack's own release cadence. The aliases below fail
+ * `tsc` if any such field is added to {@link NetworkInfo},
+ * {@link ExecutionNetworkInfo}, or {@link SparkNetworkInfo}; they are erased at
+ * runtime. Runtime counterpart: `network-info-address-invariant.spec.ts`.
  */
 type ForbiddenTradingAddressKey =
-  // The canonical set the issue calls out.
+  // Known trading-stack address fields.
   | "conductorAddress"
   | "wbtcAddress"
   | "factoryAddress"
@@ -306,15 +296,11 @@ type ForbiddenTradingAddressKey =
   | "v3FactoryAddress";
 
 /**
- * `true` when `T` carries no forbidden trading-stack address key.
+ * `true` when `T` has no forbidden trading-stack address key.
  *
- * Scope: this inspects only the *top-level* `keyof T` of each interface as a
- * flat literal-key union — matching the gateway's flat wire shape. It does not
- * recurse into sub-objects, and an index signature (`[k: string]: unknown`)
- * would widen `keyof T` to `string` and make the check vacuously `true`.
- * Neither is how these response interfaces are written; introducing either is
- * a deliberate, reviewable change. Keep the wire shape flat and literal-keyed
- * so this guard stays meaningful.
+ * Checks top-level literal keys only (matching the flat wire shape) — it does
+ * not recurse, and an index signature would make it vacuously `true`. Keep the
+ * response interfaces flat and literal-keyed so the guard stays meaningful.
  */
 type HasNoTradingAddress<T> = Extract<
   keyof T,
@@ -326,9 +312,8 @@ type HasNoTradingAddress<T> = Extract<
 /** Resolves only when `T` is exactly `true`; any other input is a compile error. */
 type AssertTrue<T extends true> = T;
 
-// Adding e.g. `conductorAddress` to any of these interfaces flips its
-// `HasNoTradingAddress` result to `false`, violating the `AssertTrue`
-// constraint and failing the build. See the doc block above.
+// Adding a forbidden key to any interface flips its check to `false` and
+// fails the build via the AssertTrue constraint.
 type _NetworkInfoHasNoTradingAddress = AssertTrue<
   HasNoTradingAddress<NetworkInfo>
 >;

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -290,14 +290,32 @@ export interface ExecutionNetworkInfo {
  * `network-info-address-invariant.spec.ts`.
  */
 type ForbiddenTradingAddressKey =
+  // The canonical set the issue calls out.
   | "conductorAddress"
   | "wbtcAddress"
   | "factoryAddress"
   | "positionManagerAddress"
   | "permit2Address"
-  | "uniswapFactoryAddress";
+  | "uniswapFactoryAddress"
+  // Defensive synonyms a future contributor might reach for instead.
+  | "nonfungiblePositionManagerAddress"
+  | "npmAddress"
+  | "routerAddress"
+  | "swapRouterAddress"
+  | "quoterAddress"
+  | "v3FactoryAddress";
 
-/** `true` when `T` carries no forbidden trading-stack address key. */
+/**
+ * `true` when `T` carries no forbidden trading-stack address key.
+ *
+ * Scope: this inspects only the *top-level* `keyof T` of each interface as a
+ * flat literal-key union — matching the gateway's flat wire shape. It does not
+ * recurse into sub-objects, and an index signature (`[k: string]: unknown`)
+ * would widen `keyof T` to `string` and make the check vacuously `true`.
+ * Neither is how these response interfaces are written; introducing either is
+ * a deliberate, reviewable change. Keep the wire shape flat and literal-keyed
+ * so this guard stays meaningful.
+ */
 type HasNoTradingAddress<T> = Extract<
   keyof T,
   ForbiddenTradingAddressKey


### PR DESCRIPTION
## Summary

Guardrail to keep trading-stack contract addresses (Conductor, WBTC, Uniswap V3 factory, NonfungiblePositionManager, Permit2) off the gateway `/api/v1/network/info` typed surface. They belong in `AMMConfig`, since they move on the trading stack's own release cadence — independent of the execution-gateway lifecycle. No behavior change; this just makes the invariant impossible to regress silently.

## Changes

- **Compile-time guard** in `src/execution/types.ts`: `AssertTrue<HasNoTradingAddress<...>>` over `NetworkInfo` / `ExecutionNetworkInfo` / `SparkNetworkInfo`. Adding a trading-address field fails `tsc` (and `build`); the aliases are erased at runtime.
- **Runtime spec** pinning the expected wire shape and asserting no trading-stack key appears at any level.
- Doc note on `NetworkInfo`.

## Test plan

- [x] `tsc --noEmit` (incl. a negative check: a forbidden key fails to compile)
- [x] `jest` network-info specs
- [x] `npm run build`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard `NetworkInfo` against trading-stack address fields with compile-time and runtime checks
> - Adds compile-time guardrail types in [types.ts](https://github.com/flashnetxyz/ts-sdk/pull/69/files#diff-ab028f912c24c154bc692cc1d065e239a88f71059e060466969b99ba2966b936): `ForbiddenTradingAddressKey`, `HasNoTradingAddress<T>`, and three assertion aliases that cause `tsc` to fail if a forbidden key is added to `NetworkInfo`, `ExecutionNetworkInfo`, or `SparkNetworkInfo`.
> - Adds a Jest test suite in [network-info-address-invariant.spec.ts](https://github.com/flashnetxyz/ts-sdk/pull/69/files#diff-d22a8b5421ce2769e8a3eac8f79cfeaa39aa39d05b630bc4a3b1ea0b6e98aefd) that asserts forbidden trading-stack keys never appear in the `/api/v1/network/info` payload, including when the gateway returns a polluted response with extra fields.
> - Documents in `NetworkInfo` that trading-stack contract addresses are intentionally absent and live in `AMMConfig`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 971f86f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->