### PR TITLE
feat(sdk): auto-clawback for stranded swap & LP funding

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -70,7 +70,7 @@ export type {
 } from "./src/execution";
 
 // Trading client (wraps ExecutionClient for DEX operations)
-export { TradingClient, SwapDepositStrandedError, satsToWei, weiToSats } from "./src/trading";
+export { TradingClient, StrandedFundingError, satsToWei, weiToSats } from "./src/trading";
 export type {
   TradingConfig,
   SwapParams as TradingSwapParams,

--- a/src/execution/client.ts
+++ b/src/execution/client.ts
@@ -46,6 +46,7 @@ import { fetchNonce, fetchEip1559Fees, fetchNativeBalance } from "./evm";
 import {
   PLACEHOLDER_DEPOSIT_PROOF,
   canonicalIntentId,
+  clawbackSparkTxidWire,
   depositAssetToWire,
   isTerminalIntentStatus,
   normalizeIntentStatus,
@@ -56,6 +57,7 @@ import type {
   CanonicalIntentAction,
   CanonicalIntentMessage,
   CanonicalTransferEntry,
+  ClawbackResult,
   Deposit,
   DepositRejection,
   ExecuteResponse,
@@ -782,6 +784,65 @@ export class ExecutionClient {
   }
 
   /**
+   * Request a refund of a Spark transfer whose intent never finalized on EVM.
+   *
+   * Submits an `IntentAction::Clawback` (no deposits): the sequencer resolves
+   * the original transfer from custody, plans a `SparkGateway.refundTx`, and
+   * returns the funds to the original Spark sender.
+   *
+   * Eligibility is enforced server-side — the transfer must exist in custody
+   * and must not have been consumed by a finalized intent, and the caller's
+   * identity key must match the original sender. A clawback for a transfer
+   * that already finalized is rejected; treat that as "already settled", not
+   * a transient error to retry.
+   *
+   * @param sparkTxid Hex Spark transfer id returned when the funding transfer
+   *   was made.
+   */
+  async clawback(
+    sparkTxid: string,
+    opts?: { expiresAt?: number }
+  ): Promise<ExecuteResponse> {
+    this.requireAuth();
+    return this.submitIntent(
+      [],
+      { type: "clawback", sparkTxid },
+      {
+        // Ignored for clawback by `canonicalIntentId` (it zeroes the
+        // recipient), but the field is non-optional on `submitIntent`.
+        recipientForHash: "0x0000000000000000000000000000000000000000",
+        clawback: { sparkTxid },
+        expiresAt: opts?.expiresAt,
+      }
+    );
+  }
+
+  /**
+   * Attempt to claw back several Spark transfers, one intent each. Never
+   * throws on an individual failure: returns a per-transfer result so callers
+   * can report recovered vs. still-at-risk.
+   */
+  async clawbackMany(
+    sparkTxids: string[],
+    opts?: { expiresAt?: number }
+  ): Promise<ClawbackResult[]> {
+    const results: ClawbackResult[] = [];
+    for (const sparkTxid of sparkTxids) {
+      try {
+        const response = await this.clawback(sparkTxid, opts);
+        results.push({ transferId: sparkTxid, success: true, response });
+      } catch (err) {
+        results.push({
+          transferId: sparkTxid,
+          success: false,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    return results;
+  }
+
+  /**
    * Look up the lifecycle status of a previously submitted intent.
    *
    * Calls `GET /api/v1/intents/{submissionId}` on the gateway. No auth
@@ -954,6 +1015,12 @@ export class ExecutionClient {
        * flows that is the SDK's own EVM address). Ignored for Clawback.
        */
       recipientForHash: string;
+      /**
+       * Clawback target. When set, the body carries a `clawback` action and
+       * `rawDeposits` MUST be empty. Mutually exclusive with `recipient` and
+       * `evmTransaction`.
+       */
+      clawback?: { sparkTxid: string };
       expiresAt?: number;
       manualProofs?: boolean;
     }
@@ -1016,10 +1083,21 @@ export class ExecutionClient {
     // keys (or the Rust struct) silently breaks auth — the signed
     // bytes diverge but no type-level error surfaces. A golden-vector
     // test in stringify-bigint.spec.ts locks in the current ordering.
-    const canonicalMessage: CanonicalIntentMessage = {
+    // The signed message must byte-match the gateway's serde output. For
+    // clawback the action's `sparkTxid` is a `SparkTransferId` enum on the Rust
+    // side, serialized externally tagged as `{ Bitcoin|Token: [...bytes] }` —
+    // NOT the hex string carried in the request body and the BLAKE3 preimage.
+    const messageAction =
+      action.type === "clawback"
+        ? {
+            type: "clawback" as const,
+            sparkTxid: clawbackSparkTxidWire(action.sparkTxid),
+          }
+        : action;
+    const canonicalMessage = {
       chainId: this.config.chainId,
       transfers,
-      action,
+      action: messageAction,
       expiresAt,
     };
 
@@ -1051,6 +1129,9 @@ export class ExecutionClient {
     }
     if (requestAction.evmTransaction) {
       body.evmTransaction = requestAction.evmTransaction;
+    }
+    if (requestAction.clawback) {
+      body.clawback = { sparkTxid: requestAction.clawback.sparkTxid };
     }
 
     const resp = await this.post<ExecuteResponse>("/api/v1/execute", body, {

--- a/src/execution/client.ts
+++ b/src/execution/client.ts
@@ -58,6 +58,7 @@ import type {
   CanonicalIntentMessage,
   CanonicalTransferEntry,
   ClawbackResult,
+  ClawbackSparkTxidWire,
   Deposit,
   DepositRejection,
   ExecuteResponse,
@@ -1087,6 +1088,15 @@ export class ExecutionClient {
     // clawback the action's `sparkTxid` is a `SparkTransferId` enum on the Rust
     // side, serialized externally tagged as `{ Bitcoin|Token: [...bytes] }` —
     // NOT the hex string carried in the request body and the BLAKE3 preimage.
+    // Type the message against a wire-form of `CanonicalIntentMessage` derived
+    // from the canonical type (the clawback `sparkTxid` above is the byte enum,
+    // not the hex `CanonicalIntentAction` form), so a later rename/reorder of
+    // the shared fields still fails to compile here.
+    type CanonicalIntentMessageWire = Omit<CanonicalIntentMessage, "action"> & {
+      action:
+        | Exclude<CanonicalIntentAction, { type: "clawback" }>
+        | { type: "clawback"; sparkTxid: ClawbackSparkTxidWire };
+    };
     const messageAction =
       action.type === "clawback"
         ? {
@@ -1094,7 +1104,7 @@ export class ExecutionClient {
             sparkTxid: clawbackSparkTxidWire(action.sparkTxid),
           }
         : action;
-    const canonicalMessage = {
+    const canonicalMessage: CanonicalIntentMessageWire = {
       chainId: this.config.chainId,
       transfers,
       action: messageAction,

--- a/src/execution/stringify-bigint.spec.ts
+++ b/src/execution/stringify-bigint.spec.ts
@@ -1,4 +1,5 @@
 import { stringifyWithBigint } from "./client";
+import { clawbackSparkTxidWire } from "./types";
 import type {
   CanonicalIntentMessage,
   CanonicalTransferEntry,
@@ -142,5 +143,40 @@ describe("stringifyWithBigint", () => {
         '"action":{"type":"deposit","recipient":"0xabc"},' +
         '"expiresAt":1893456000000}'
     );
+  });
+
+  // Golden vector for a clawback message. The gateway signs the
+  // `SparkTransferId` enum externally tagged with a decimal byte array
+  // (`{"Token":[..32]}` / `{"Bitcoin":[..16]}`), NOT a hex string. Inputs
+  // mirror the Rust `clawback_intent_serializes_with_empty_transfers` test
+  // (0xFF*32, chainId 21022, expiresAt 9999999999000) so the two are directly
+  // comparable. If this drifts, clawback signature verification fails at the
+  // gateway.
+  it("clawback canonical message matches the Rust serde wire form", () => {
+    const message = {
+      chainId: 21022,
+      transfers: [] as CanonicalTransferEntry[],
+      action: {
+        type: "clawback" as const,
+        sparkTxid: clawbackSparkTxidWire("0x" + "ff".repeat(32)),
+      },
+      expiresAt: 9_999_999_999_000,
+    };
+    const tokenBytes = Array(32).fill(255).join(",");
+    expect(stringifyWithBigint(message)).toEqual(
+      '{"chainId":21022,"transfers":[],' +
+        `"action":{"type":"clawback","sparkTxid":{"Token":[${tokenBytes}]}},` +
+        '"expiresAt":9999999999000}'
+    );
+  });
+
+  it("clawbackSparkTxidWire dispatches Bitcoin (16B) vs Token (32B) by length", () => {
+    expect(clawbackSparkTxidWire("0x" + "ab".repeat(16))).toEqual({
+      Bitcoin: Array(16).fill(0xab),
+    });
+    expect(clawbackSparkTxidWire("cd".repeat(32))).toEqual({
+      Token: Array(32).fill(0xcd),
+    });
+    expect(() => clawbackSparkTxidWire("00".repeat(20))).toThrow(/must be 16/);
   });
 });

--- a/src/execution/stringify-bigint.spec.ts
+++ b/src/execution/stringify-bigint.spec.ts
@@ -152,6 +152,11 @@ describe("stringifyWithBigint", () => {
   // (0xFF*32, chainId 21022, expiresAt 9999999999000) so the two are directly
   // comparable. If this drifts, clawback signature verification fails at the
   // gateway.
+  //
+  // Cross-checked: this exact string equals `serde_json::to_string` of the
+  // Rust clawback `CanonicalIntentMessage` (captured by running the
+  // `flashnet-auth` `clawback_intent_serializes_with_empty_transfers` test),
+  // so the SDK signs the bytes the gateway verifies, not just a derived guess.
   it("clawback canonical message matches the Rust serde wire form", () => {
     const message = {
       chainId: 21022,

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -403,6 +403,18 @@ export interface ClawbackResult {
   error?: string;
 }
 
+/** Aggregate result of an automatic clawback over one or more transfers. */
+export interface ClawbackSummary {
+  /** Whether a clawback was attempted (false when no funds were committed). */
+  attempted: boolean;
+  /** Transfers the gateway accepted a clawback for (returned to the sender). */
+  recoveredTransferIds: string[];
+  /** Transfers whose clawback was rejected — still at risk, may need manual recovery. */
+  unrecoveredTransferIds: string[];
+  /** Per-transfer detail. */
+  results: ClawbackResult[];
+}
+
 /**
  * Canonical intent message that gets signed by the client.
  *

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -387,6 +387,22 @@ export type CanonicalIntentAction =
   | { type: "execute"; signedTxHash: string }
   | { type: "clawback"; sparkTxid: string };
 
+/** Outcome of a single clawback attempt. Never represents a thrown error. */
+export interface ClawbackResult {
+  /** The Spark transfer id this attempt targeted. */
+  transferId: string;
+  /** Whether the gateway accepted the clawback intent. */
+  success: boolean;
+  /** Gateway response when accepted. */
+  response?: ExecuteResponse;
+  /**
+   * Failure message when rejected. A rejection commonly means the transfer
+   * was already consumed by a finalized intent (so no refund is owed), not a
+   * transient error to retry.
+   */
+  error?: string;
+}
+
 /**
  * Canonical intent message that gets signed by the client.
  *
@@ -503,6 +519,32 @@ function hexToBytes(hex: string): Uint8Array {
 function normalizeIdHex(id: string): string {
   const noPrefix = id.startsWith("0x") || id.startsWith("0X") ? id.slice(2) : id;
   return noPrefix.replace(/-/g, "");
+}
+
+/**
+ * Externally-tagged wire form of a clawback `sparkTxid` as it appears in the
+ * signed canonical intent message.
+ *
+ * The gateway's `CanonicalIntentAction::Clawback.spark_txid` is a
+ * `SparkTransferId` enum (`Bitcoin([u8; 16])` / `Token([u8; 32])`) with a plain
+ * derived `Serialize`, so serde emits it externally tagged with a decimal byte
+ * array and a PascalCase variant key: `{ "Bitcoin": [..16] }` or
+ * `{ "Token": [..32] }`. The signature is verified against this JSON
+ * byte-for-byte, so the SDK must reproduce the exact shape.
+ *
+ * This is ONLY for the signed message. The `/execute` request body and the
+ * BLAKE3 intent-id preimage both use the bare-hex string form.
+ */
+export type ClawbackSparkTxidWire = { Bitcoin: number[] } | { Token: number[] };
+
+/** Build the {@link ClawbackSparkTxidWire} form from a hex transfer id. */
+export function clawbackSparkTxidWire(sparkTxid: string): ClawbackSparkTxidWire {
+  const bytes = Array.from(hexToBytes(normalizeIdHex(sparkTxid)));
+  if (bytes.length === 16) return { Bitcoin: bytes };
+  if (bytes.length === 32) return { Token: bytes };
+  throw new Error(
+    `clawback sparkTxid must be 16 (Bitcoin) or 32 (Token) bytes, got ${bytes.length}`
+  );
 }
 
 /**

--- a/src/trading/client.spec.ts
+++ b/src/trading/client.spec.ts
@@ -1,6 +1,6 @@
 import { secp256k1 } from "@noble/curves/secp256k1";
 import { decodeFunctionData } from "viem";
-import { TradingClient, SwapDepositStrandedError } from "./client";
+import { TradingClient, StrandedFundingError } from "./client";
 import { ExecutionClient } from "../execution/client";
 import { conductorAbi } from "../execution/abis/conductor";
 import { encodeSparkHumanReadableTokenIdentifier } from "../utils/tokenAddress";
@@ -196,10 +196,14 @@ describe("TradingClient.swap — BTC → token deposit wiring", () => {
     const client = new ExecutionClient(wallet, EXEC_CONFIG);
     const trading = new TradingClient(client, AMM_CONFIG);
 
-    // The call throws when it reaches `fetchNonce` (no RPC running) — but
-    // by then `wallet.transfer` has already committed the deposit. The
-    // failure must surface as a SwapDepositStrandedError carrying the
-    // transferId so the stranded deposit stays recoverable.
+    // The call throws when it reaches `fetchNonce` (no RPC running) — but by
+    // then `wallet.transfer` has already committed the deposit. The failure
+    // must surface as a StrandedFundingError, and the SDK auto-claws the
+    // committed transfer back, reporting it recovered.
+    const clawbackSpy = jest
+      .spyOn(client, "clawbackMany")
+      .mockResolvedValue([{ transferId: "abc123", success: true }]);
+
     const err = await trading
       .swap({
         assetInAddress: "btc",
@@ -214,12 +218,57 @@ describe("TradingClient.swap — BTC → token deposit wiring", () => {
         (e) => e
       );
 
-    expect(err).toBeInstanceOf(SwapDepositStrandedError);
-    expect((err as SwapDepositStrandedError).transferId).toBe("abc123");
+    expect(err).toBeInstanceOf(StrandedFundingError);
+    expect((err as StrandedFundingError).transferIds).toEqual(["abc123"]);
+    expect(
+      (err as StrandedFundingError).clawbackSummary.recoveredTransferIds
+    ).toEqual(["abc123"]);
+    expect(
+      (err as StrandedFundingError).clawbackSummary.unrecoveredTransferIds
+    ).toEqual([]);
+    expect(clawbackSpy).toHaveBeenCalledWith(["abc123"]);
 
     expect(observed).not.toBeNull();
     expect(observed.amountSats).toBe(250000);
     expect(observed.receiverSparkAddress).toBe(TEST_DEPOSIT_ADDRESS);
+  });
+
+  it("surfaces unrecovered transfers when auto-clawback is rejected", async () => {
+    stubNetworkInfoFetch();
+    const wallet = mockWallet({ transferId: "def456" });
+    const client = new ExecutionClient(wallet, EXEC_CONFIG);
+    const trading = new TradingClient(client, AMM_CONFIG);
+
+    // Funding commits, the swap fails at fetchNonce, and the clawback itself
+    // is rejected (e.g. the gateway already consumed the transfer). The error
+    // must report the transfer as still at risk.
+    jest
+      .spyOn(client, "clawbackMany")
+      .mockResolvedValue([
+        { transferId: "def456", success: false, error: "transfer already used" },
+      ]);
+
+    const err = await trading
+      .swap({
+        assetInAddress: "btc",
+        assetOutAddress: "0x4444444444444444444444444444444444444444",
+        amountIn: "250000",
+        minAmountOut: "0",
+        fee: 3000,
+        useAvailableBalance: true,
+      })
+      .then(
+        () => null,
+        (e) => e
+      );
+
+    expect(err).toBeInstanceOf(StrandedFundingError);
+    expect(
+      (err as StrandedFundingError).clawbackSummary.unrecoveredTransferIds
+    ).toEqual(["def456"]);
+    expect(
+      (err as StrandedFundingError).clawbackSummary.recoveredTransferIds
+    ).toEqual([]);
   });
 });
 

--- a/src/trading/client.ts
+++ b/src/trading/client.ts
@@ -41,7 +41,11 @@ import {
   type Hex,
 } from "viem";
 import type { ExecutionClient } from "../execution/client";
-import type { Deposit, ExecuteResponse } from "../execution/types";
+import type {
+  ClawbackSummary,
+  Deposit,
+  ExecuteResponse,
+} from "../execution/types";
 import { conductorAbi } from "../execution/abis/conductor";
 import { nonfungiblePositionManagerAbi } from "../execution/abis/nonfungiblePositionManager";
 import { fetchNonce, fetchAllowance, fetchEip1559Fees } from "../execution/evm";
@@ -584,24 +588,35 @@ const TRADING_ENVIRONMENT_CONFIGS: Partial<Record<ClientEnvironment, TradingConf
 };
 
 /**
- * Thrown when a `useAvailableBalance` swap fails AFTER its funding Spark
- * transfer has already committed. The deposit is sitting at the gateway
- * deposit address; `transferId` lets the caller build a recovery deposit
- * intent instead of losing track of it. `cause` is the underlying failure
- * (nonce/fee RPC error, permit signing, gateway rejection, etc.).
+ * Thrown when a Spark-funded operation (swap round-trip, or LP add / increase
+ * / modify with `useAvailableBalance`) fails AFTER its funding transfer(s)
+ * committed. The SDK automatically attempts to claw the committed transfer(s)
+ * back to the caller's Spark balance; `clawbackSummary` reports which were
+ * recovered and which are still at risk. `transferIds` are the committed
+ * transfers; `cause` is the underlying failure.
  */
-export class SwapDepositStrandedError extends Error {
-  readonly transferId: string;
-  constructor(transferId: string, cause: unknown) {
+export class StrandedFundingError extends Error {
+  readonly transferIds: string[];
+  readonly clawbackSummary: ClawbackSummary;
+  constructor(
+    transferIds: string[],
+    clawbackSummary: ClawbackSummary,
+    cause: unknown
+  ) {
     const reason = cause instanceof Error ? cause.message : String(cause);
+    const { recoveredTransferIds, unrecoveredTransferIds } = clawbackSummary;
+    const recovery =
+      unrecoveredTransferIds.length === 0
+        ? `All ${transferIds.length} funding transfer(s) were automatically clawed back.`
+        : `Auto-clawback recovered ${recoveredTransferIds.length}/${transferIds.length}; still at risk: ${unrecoveredTransferIds.join(", ")}.`;
     super(
-      `swap funding transfer ${transferId} committed but the swap failed ` +
-        `before the intent was submitted: ${reason}. The deposit is at the ` +
-        `gateway deposit address — build a recovery intent with this transferId.`,
+      `funding transfer(s) ${transferIds.join(", ")} committed but the ` +
+        `operation failed before the intent was submitted: ${reason}. ${recovery}`,
       { cause }
     );
-    this.name = "SwapDepositStrandedError";
-    this.transferId = transferId;
+    this.name = "StrandedFundingError";
+    this.transferIds = transferIds;
+    this.clawbackSummary = clawbackSummary;
   }
 }
 
@@ -1136,6 +1151,43 @@ export class TradingClient {
   }
 
   /**
+   * Run the post-funding work of a Spark-funded operation under automatic
+   * clawback. If `op` throws after funding transfer(s) committed, claw them
+   * back to the caller's Spark balance and rethrow as
+   * {@link StrandedFundingError} with a per-transfer recovery summary.
+   *
+   * `committedTransferIds` are the transfers made before `op` runs. An empty
+   * array (no Spark funding) makes this a transparent pass-through. Clawback
+   * eligibility is enforced server-side, so a clawback for a transfer the
+   * gateway actually consumed is rejected and surfaced as unrecovered rather
+   * than double-spending.
+   */
+  private async withAutoClawback<T>(
+    committedTransferIds: string[],
+    op: () => Promise<T>
+  ): Promise<T> {
+    try {
+      return await op();
+    } catch (err) {
+      if (committedTransferIds.length === 0) {
+        throw err;
+      }
+      const results = await this.execClient.clawbackMany(committedTransferIds);
+      const summary: ClawbackSummary = {
+        attempted: true,
+        recoveredTransferIds: results
+          .filter((r) => r.success)
+          .map((r) => r.transferId),
+        unrecoveredTransferIds: results
+          .filter((r) => !r.success)
+          .map((r) => r.transferId),
+        results,
+      };
+      throw new StrandedFundingError(committedTransferIds, summary, err);
+    }
+  }
+
+  /**
    * Bundle a Spark-side deposit with the swap+withdraw in ONE execute
    * intent.
    *
@@ -1215,11 +1267,10 @@ export class TradingClient {
 
     // The funding transfer has committed. Everything past this point can
     // still fail (EIP-2612 permit signing, nonce/fee RPC inside
-    // signConductorTx, and the gateway POST in submitSwapIntent). Wrap it
-    // so any failure surfaces `transferId` via SwapDepositStrandedError —
-    // otherwise the deposit is stranded at the gateway with no way to
-    // build a recovery intent.
-    try {
+    // signConductorTx, and the gateway POST in submitSwapIntent). Run it under
+    // auto-clawback so any failure returns the deposit to the caller's Spark
+    // balance instead of stranding it at the gateway.
+    return this.withAutoClawback([transferId], async () => {
       // Step 2: build calldata.
       let calldata: string;
       let value: bigint = 0n;
@@ -1285,9 +1336,7 @@ export class TradingClient {
       // Step 3: sign + submit bundled intent.
       const signedTx = await this.signConductorTx(calldata, value);
       return await this.submitSwapIntent(signedTx, deposits, transferId);
-    } catch (err) {
-      throw new SwapDepositStrandedError(transferId, err);
-    }
+    });
   }
 
   /**

--- a/src/trading/client.ts
+++ b/src/trading/client.ts
@@ -1776,56 +1776,58 @@ export class TradingClient {
       token1SparkId: params.token1SparkId,
     });
 
-    const struct = {
-      token0,
-      token1,
-      fee: params.fee,
-      tickLower: params.tickLower,
-      tickUpper: params.tickUpper,
-      amount0Desired: amount0,
-      amount1Desired: amount1,
-      amount0Min: BigInt(params.amount0Min),
-      amount1Min: BigInt(params.amount1Min),
-      deadline,
-      sparkRecipient,
-    };
+    return this.withAutoClawback(inboundIds, async () => {
+      const struct = {
+        token0,
+        token1,
+        fee: params.fee,
+        tickLower: params.tickLower,
+        tickUpper: params.tickUpper,
+        amount0Desired: amount0,
+        amount1Desired: amount1,
+        amount0Min: BigInt(params.amount0Min),
+        amount1Min: BigInt(params.amount1Min),
+        deadline,
+        sparkRecipient,
+      };
 
-    let calldata: string;
-    let value = 0n;
-    if (isBtcPair) {
-      const otherToken = (isToken0Btc ? token1 : token0) as `0x${string}`;
-      const otherAmount = isToken0Btc ? amount1 : amount0;
-      value = isToken0Btc ? amount0 : amount1;
-      const permit = await this.buildPermit2Signature(otherToken, otherAmount);
-      calldata = encodeFunctionData({
-        abi: conductorAbi,
-        functionName: "addLiquidityBTC",
-        args: [struct, permit.permitTransfer, permit.signature],
-      });
-    } else {
-      const [permitA, permitB] = await Promise.all([
-        this.buildPermit2Signature(token0, amount0),
-        this.buildPermit2Signature(token1, amount1),
-      ]);
-      calldata = encodeFunctionData({
-        abi: conductorAbi,
-        functionName: "addLiquidity",
-        args: [
-          struct,
-          permitA.permitTransfer,
-          permitA.signature,
-          permitB.permitTransfer,
-          permitB.signature,
-        ],
-      });
-    }
+      let calldata: string;
+      let value = 0n;
+      if (isBtcPair) {
+        const otherToken = (isToken0Btc ? token1 : token0) as `0x${string}`;
+        const otherAmount = isToken0Btc ? amount1 : amount0;
+        value = isToken0Btc ? amount0 : amount1;
+        const permit = await this.buildPermit2Signature(otherToken, otherAmount);
+        calldata = encodeFunctionData({
+          abi: conductorAbi,
+          functionName: "addLiquidityBTC",
+          args: [struct, permit.permitTransfer, permit.signature],
+        });
+      } else {
+        const [permitA, permitB] = await Promise.all([
+          this.buildPermit2Signature(token0, amount0),
+          this.buildPermit2Signature(token1, amount1),
+        ]);
+        calldata = encodeFunctionData({
+          abi: conductorAbi,
+          functionName: "addLiquidity",
+          args: [
+            struct,
+            permitA.permitTransfer,
+            permitA.signature,
+            permitB.permitTransfer,
+            permitB.signature,
+          ],
+        });
+      }
 
-    const signedTx = await this.signConductorTx(
-      calldata,
-      value,
-      this.config.lpGasLimit ?? DEFAULT_LP_GAS_LIMIT
-    );
-    return this.submitLpIntent(signedTx, deposits, inboundIds);
+      const signedTx = await this.signConductorTx(
+        calldata,
+        value,
+        this.config.lpGasLimit ?? DEFAULT_LP_GAS_LIMIT
+      );
+      return this.submitLpIntent(signedTx, deposits, inboundIds);
+    });
   }
 
   /**
@@ -1857,52 +1859,54 @@ export class TradingClient {
       token1SparkId: params.token1SparkId,
     });
 
-    const struct = {
-      tokenId,
-      amount0Desired: amount0,
-      amount1Desired: amount1,
-      amount0Min: BigInt(params.amount0Min),
-      amount1Min: BigInt(params.amount1Min),
-      deadline,
-      sparkRecipient,
-    };
+    return this.withAutoClawback(inboundIds, async () => {
+      const struct = {
+        tokenId,
+        amount0Desired: amount0,
+        amount1Desired: amount1,
+        amount0Min: BigInt(params.amount0Min),
+        amount1Min: BigInt(params.amount1Min),
+        deadline,
+        sparkRecipient,
+      };
 
-    let calldata: string;
-    let value = 0n;
-    if (isBtcPair) {
-      const otherToken = (isToken0Btc ? token1 : token0) as `0x${string}`;
-      const otherAmount = isToken0Btc ? amount1 : amount0;
-      value = isToken0Btc ? amount0 : amount1;
-      const permit = await this.buildPermit2Signature(otherToken, otherAmount);
-      calldata = encodeFunctionData({
-        abi: conductorAbi,
-        functionName: "increaseLiquidityBTC",
-        args: [struct, permit.permitTransfer, permit.signature],
-      });
-    } else {
-      const [permitA, permitB] = await Promise.all([
-        this.buildPermit2Signature(token0, amount0),
-        this.buildPermit2Signature(token1, amount1),
-      ]);
-      calldata = encodeFunctionData({
-        abi: conductorAbi,
-        functionName: "increaseLiquidity",
-        args: [
-          struct,
-          permitA.permitTransfer,
-          permitA.signature,
-          permitB.permitTransfer,
-          permitB.signature,
-        ],
-      });
-    }
+      let calldata: string;
+      let value = 0n;
+      if (isBtcPair) {
+        const otherToken = (isToken0Btc ? token1 : token0) as `0x${string}`;
+        const otherAmount = isToken0Btc ? amount1 : amount0;
+        value = isToken0Btc ? amount0 : amount1;
+        const permit = await this.buildPermit2Signature(otherToken, otherAmount);
+        calldata = encodeFunctionData({
+          abi: conductorAbi,
+          functionName: "increaseLiquidityBTC",
+          args: [struct, permit.permitTransfer, permit.signature],
+        });
+      } else {
+        const [permitA, permitB] = await Promise.all([
+          this.buildPermit2Signature(token0, amount0),
+          this.buildPermit2Signature(token1, amount1),
+        ]);
+        calldata = encodeFunctionData({
+          abi: conductorAbi,
+          functionName: "increaseLiquidity",
+          args: [
+            struct,
+            permitA.permitTransfer,
+            permitA.signature,
+            permitB.permitTransfer,
+            permitB.signature,
+          ],
+        });
+      }
 
-    const signedTx = await this.signConductorTx(
-      calldata,
-      value,
-      this.config.lpGasLimit ?? DEFAULT_LP_GAS_LIMIT
-    );
-    return this.submitLpIntent(signedTx, deposits, inboundIds);
+      const signedTx = await this.signConductorTx(
+        calldata,
+        value,
+        this.config.lpGasLimit ?? DEFAULT_LP_GAS_LIMIT
+      );
+      return this.submitLpIntent(signedTx, deposits, inboundIds);
+    });
   }
 
   /**
@@ -2007,60 +2011,62 @@ export class TradingClient {
       token1SparkId: params.token1SparkId,
     });
 
-    const struct = {
-      tokenId,
-      newTickLower: params.newTickLower,
-      newTickUpper: params.newTickUpper,
-      amount0Min: BigInt(params.amount0Min),
-      amount1Min: BigInt(params.amount1Min),
-      additionalAmount0Desired: add0,
-      additionalAmount1Desired: add1,
-      newAmount0Min: BigInt(params.newAmount0Min),
-      newAmount1Min: BigInt(params.newAmount1Min),
-      deadline,
-      sparkRecipient,
-    };
+    return this.withAutoClawback(inboundIds, async () => {
+      const struct = {
+        tokenId,
+        newTickLower: params.newTickLower,
+        newTickUpper: params.newTickUpper,
+        amount0Min: BigInt(params.amount0Min),
+        amount1Min: BigInt(params.amount1Min),
+        additionalAmount0Desired: add0,
+        additionalAmount1Desired: add1,
+        newAmount0Min: BigInt(params.newAmount0Min),
+        newAmount1Min: BigInt(params.newAmount1Min),
+        deadline,
+        sparkRecipient,
+      };
 
-    let calldata: string;
-    let value = 0n;
-    if (isBtcPair) {
-      const otherToken = (isToken0Btc ? token1 : token0) as `0x${string}`;
-      const otherAdd = isToken0Btc ? add1 : add0;
-      value = isToken0Btc ? add0 : add1;
-      const permit = await this.buildPermit2Signature(otherToken, otherAdd);
-      calldata = encodeFunctionData({
-        abi: conductorAbi,
-        functionName: "modifyPositionBTC",
-        args: [struct, nftPermit, permit.permitTransfer, permit.signature],
-      });
-    } else {
-      // The Conductor binds permitA/permitB to token0/token1 unconditionally
-      // (even when the additional amount is zero), so always sign both with
-      // the correct token; a zero-amount permit is a no-op on the pull.
-      const [permitA, permitB] = await Promise.all([
-        this.buildPermit2Signature(token0, add0),
-        this.buildPermit2Signature(token1, add1),
-      ]);
-      calldata = encodeFunctionData({
-        abi: conductorAbi,
-        functionName: "modifyPosition",
-        args: [
-          struct,
-          nftPermit,
-          permitA.permitTransfer,
-          permitA.signature,
-          permitB.permitTransfer,
-          permitB.signature,
-        ],
-      });
-    }
+      let calldata: string;
+      let value = 0n;
+      if (isBtcPair) {
+        const otherToken = (isToken0Btc ? token1 : token0) as `0x${string}`;
+        const otherAdd = isToken0Btc ? add1 : add0;
+        value = isToken0Btc ? add0 : add1;
+        const permit = await this.buildPermit2Signature(otherToken, otherAdd);
+        calldata = encodeFunctionData({
+          abi: conductorAbi,
+          functionName: "modifyPositionBTC",
+          args: [struct, nftPermit, permit.permitTransfer, permit.signature],
+        });
+      } else {
+        // The Conductor binds permitA/permitB to token0/token1 unconditionally
+        // (even when the additional amount is zero), so always sign both with
+        // the correct token; a zero-amount permit is a no-op on the pull.
+        const [permitA, permitB] = await Promise.all([
+          this.buildPermit2Signature(token0, add0),
+          this.buildPermit2Signature(token1, add1),
+        ]);
+        calldata = encodeFunctionData({
+          abi: conductorAbi,
+          functionName: "modifyPosition",
+          args: [
+            struct,
+            nftPermit,
+            permitA.permitTransfer,
+            permitA.signature,
+            permitB.permitTransfer,
+            permitB.signature,
+          ],
+        });
+      }
 
-    const signedTx = await this.signConductorTx(
-      calldata,
-      value,
-      this.config.lpGasLimit ?? DEFAULT_LP_GAS_LIMIT
-    );
-    return this.submitLpIntent(signedTx, deposits, inboundIds);
+      const signedTx = await this.signConductorTx(
+        calldata,
+        value,
+        this.config.lpGasLimit ?? DEFAULT_LP_GAS_LIMIT
+      );
+      return this.submitLpIntent(signedTx, deposits, inboundIds);
+    });
   }
 
   /**
@@ -2280,11 +2286,16 @@ export class TradingClient {
       inboundIds.push(leg.transferId);
     }
     if (opts.amount1 > 0n) {
-      const leg = await this.fundLpLeg(
-        opts.isToken1Btc,
-        opts.amount1,
-        opts.token1SparkId,
-        custody
+      // The first leg's transfer has already committed. If this one throws,
+      // claw the first leg back instead of stranding it (no-op when the first
+      // leg was zero-amount, since `inboundIds` is then empty).
+      const leg = await this.withAutoClawback(inboundIds.slice(), () =>
+        this.fundLpLeg(
+          opts.isToken1Btc,
+          opts.amount1,
+          opts.token1SparkId,
+          custody
+        )
       );
       deposits.push(leg.deposit);
       inboundIds.push(leg.transferId);

--- a/src/trading/client.ts
+++ b/src/trading/client.ts
@@ -42,6 +42,7 @@ import {
 } from "viem";
 import type { ExecutionClient } from "../execution/client";
 import type {
+  ClawbackResult,
   ClawbackSummary,
   Deposit,
   ExecuteResponse,
@@ -611,7 +612,7 @@ export class StrandedFundingError extends Error {
         : `Auto-clawback recovered ${recoveredTransferIds.length}/${transferIds.length}; still at risk: ${unrecoveredTransferIds.join(", ")}.`;
     super(
       `funding transfer(s) ${transferIds.join(", ")} committed but the ` +
-        `operation failed before the intent was submitted: ${reason}. ${recovery}`,
+        `operation then failed: ${reason}. ${recovery}`,
       { cause }
     );
     this.name = "StrandedFundingError";
@@ -1172,7 +1173,19 @@ export class TradingClient {
       if (committedTransferIds.length === 0) {
         throw err;
       }
-      const results = await this.execClient.clawbackMany(committedTransferIds);
+      // `clawbackMany` never throws per its contract, but localize the
+      // StrandedFundingError guarantee here so a future contract change can't
+      // strand the caller without the committed transfer ids.
+      let results: ClawbackResult[];
+      try {
+        results = await this.execClient.clawbackMany(committedTransferIds);
+      } catch {
+        results = committedTransferIds.map((transferId) => ({
+          transferId,
+          success: false,
+          error: "clawback request failed",
+        }));
+      }
       const summary: ClawbackSummary = {
         attempted: true,
         recoveredTransferIds: results

--- a/src/trading/index.ts
+++ b/src/trading/index.ts
@@ -8,7 +8,7 @@
 
 export {
   TradingClient,
-  SwapDepositStrandedError,
+  StrandedFundingError,
   type TradingConfig,
   type SwapParams,
   type SwapResult,

--- a/src/trading/liquidity.spec.ts
+++ b/src/trading/liquidity.spec.ts
@@ -28,7 +28,12 @@ import { nonfungiblePositionManagerAbi } from "../execution/abis/nonfungiblePosi
 import { ExecutionClient } from "../execution/client";
 import type { SparkWalletInput } from "../execution/spark-evm-account";
 import { encodeSparkHumanReadableTokenIdentifier } from "../utils/tokenAddress";
-import { TradingClient, satsToWei, weiToSats } from "./client";
+import {
+  StrandedFundingError,
+  TradingClient,
+  satsToWei,
+  weiToSats,
+} from "./client";
 
 const TEST_KEY = new Uint8Array(32);
 TEST_KEY[31] = 1;
@@ -478,6 +483,60 @@ describe("TradingClient.addLiquidity (ERC20/ERC20)", () => {
     expect(body?.deposits).toHaveLength(2);
     expect(res.inboundSparkTransferIds).toHaveLength(2);
     expect(decodeLastCall().functionName).toBe("addLiquidity");
+  });
+
+  it("auto-claws back both legs when a funded addLiquidity fails post-funding", async () => {
+    let tokenTransfers = 0;
+    const amm = await makeClient({ onTransferTokens: () => tokenTransfers++ });
+    const exec = (amm as any).execClient as ExecutionClient;
+
+    // Both legs' transfers commit, then signing fails (RPC down). The SDK must
+    // claw both committed transfers back rather than strand them.
+    jest
+      .spyOn(amm as any, "signConductorTx")
+      .mockRejectedValue(new Error("nonce/fee RPC unavailable"));
+    let clawedIds: string[] = [];
+    const clawbackSpy = jest
+      .spyOn(exec, "clawbackMany")
+      .mockImplementation(async (ids: string[]) => {
+        clawedIds = ids;
+        return ids.map((id) => ({ transferId: id, success: true }));
+      });
+
+    const err = await amm
+      .addLiquidity({
+        token0: TOKEN_A,
+        token1: TOKEN_B,
+        fee: 3000,
+        tickLower: -60,
+        tickUpper: 60,
+        amount0Desired: "1000",
+        amount1Desired: "2000",
+        amount0Min: "0",
+        amount1Min: "0",
+        useAvailableBalance: true,
+        token0SparkId: encodeSparkHumanReadableTokenIdentifier(
+          "aa".repeat(32),
+          "REGTEST"
+        ),
+        token1SparkId: encodeSparkHumanReadableTokenIdentifier(
+          "bb".repeat(32),
+          "REGTEST"
+        ),
+      })
+      .then(
+        () => null,
+        (e) => e
+      );
+
+    expect(tokenTransfers).toBe(2);
+    expect(err).toBeInstanceOf(StrandedFundingError);
+    expect(clawbackSpy).toHaveBeenCalledTimes(1);
+    expect(clawedIds).toHaveLength(2);
+    expect((err as StrandedFundingError).transferIds).toEqual(clawedIds);
+    expect(
+      (err as StrandedFundingError).clawbackSummary.recoveredTransferIds
+    ).toEqual(clawedIds);
   });
 
   it("refuses the Spark-funded ERC20 path when Permit2 is not approved, before transferring", async () => {


### PR DESCRIPTION
## What

When a Spark-funded operation fails *after* its funding transfer(s) commit (swap round-trip, or LP `addLiquidity`/`increaseLiquidity`/`modifyPosition` with `useAvailableBalance`), the SDK now automatically claws the committed transfer(s) back to the caller's Spark balance and throws a typed `StrandedFundingError` reporting recovered vs. still-at-risk transfers.

Before this, the swap path had only a handle-only error (surfaced the id, no recovery); the LP path had no guard at all and could strand up to two committed transfers.

## How

- **`ExecutionClient.clawback(sparkTxid)` / `clawbackMany(ids)`** — submit `IntentAction::Clawback` via the existing `/execute` path. The gateway resolves the original transfer and refunds the sender. Eligibility (transfer in custody, not finalized, signer = sender) is enforced server-side, so a clawback for a transfer that actually finalized is rejected rather than double-spent.
- **`StrandedFundingError`** (replaces the unreleased `SwapDepositStrandedError`) carries all committed `transferIds` plus a `ClawbackSummary` (recovered / unrecovered / per-transfer results).
- **`withAutoClawback(committedIds, op)`** — runs the post-funding work; on failure claws the committed transfers back and rethrows the typed error. Empty ids (no Spark funding) is a transparent pass-through.
- Swap and the three LP methods run build+sign+submit under the wrapper; `fundTwoLegs` additionally wraps the second leg so a leg-2 failure claws the first (already committed) leg back.

## Signing detail (verified)

The clawback action's `sparkTxid` is a `SparkTransferId` enum on the gateway, serialized externally tagged as `{ "Bitcoin"|"Token": [..bytes] }` (decimal byte array), **not** a hex string. The signed canonical message must byte-match that, so `clawbackSparkTxidWire` reproduces the enum form; the `/execute` request body and the BLAKE3 intent-id preimage keep the hex string.

The SDK golden vector was **cross-checked against the real gateway serializer**: it is byte-identical to `serde_json::to_string` of the Rust clawback `CanonicalIntentMessage` (captured from `flashnet-auth`'s `clawback_intent_serializes_with_empty_transfers`). So the SDK signs exactly what the gateway verifies. (The 32-byte `Token` case was run through Rust; the 16-byte `Bitcoin` case follows the same derive and is covered by the wire-dispatch unit test.)

## Notes

- **No gateway changes**: the `IntentAction::Clawback` path is already built and live in flashnet-execution.
- `SwapDepositStrandedError` was renamed (not aliased) because it was unreleased (epic-only, never on `main`).
- Unit tests mock `clawbackMany`, so the auto-clawback control flow and the message serialization are each verified, but never together against a live gateway. A one-shot e2e clawback round-trip (funding → fail → refund landing in Spark) is still the ideal final proof before mainnet.

## Test
`tsc` clean, **139 jest tests** (golden vector cross-checked vs Rust serde + Bitcoin/Token wire dispatch, swap recovered/unrecovered, LP recovered), `rollup` build green.

Stacked on the `conductor-mainnet` epic.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add auto-clawback for stranded Spark funding in swap and LP operations
> - Adds `ExecutionClient.clawback` and `clawbackMany` methods that submit clawback intents to `POST /api/v1/execute` for one or more Spark transfer IDs, returning per-transfer `ClawbackResult` entries without throwing on individual failures.
> - Adds `TradingClient.withAutoClawback` private helper that wraps post-funding steps and, on failure, calls `clawbackMany` on any committed transfer IDs before rethrowing.
> - Applies `withAutoClawback` to the Spark-funded paths of `swap`, `addLiquidity`, `increaseLiquidity`, and `modifyPosition` in [client.ts](https://github.com/flashnetxyz/ts-sdk/pull/75/files#diff-4165174c6e0b81db94283e2942fb60d7dbff390796c20a63cbcac6b461278421).
> - Replaces `SwapDepositStrandedError` with `StrandedFundingError`, which includes the committed transfer IDs and a `ClawbackSummary` of recovered vs. unrecovered transfers.
> - Introduces `clawbackSparkTxidWire` utility in [types.ts](https://github.com/flashnetxyz/ts-sdk/pull/75/files#diff-ab028f912c24c154bc692cc1d065e239a88f71059e060466969b99ba2966b936) that converts a hex Spark transfer ID to its externally tagged wire form (`{ Bitcoin: [...16] }` or `{ Token: [...32] }`).
> - Behavioral Change: code that catches `SwapDepositStrandedError` must be updated to catch `StrandedFundingError`; the error now includes clawback recovery state rather than just the stranded transfer ID.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c848d87.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->