### PR TITLE
feat(trading): client-side swap quoting (UX-04 off the gateway)

### DIFF
--- a/src/execution/abis/conductor.ts
+++ b/src/execution/abis/conductor.ts
@@ -675,4 +675,34 @@ export const conductorAbi = [
     ],
     anonymous: false,
   },
+  // Fee getters — read-only views used by client-side swap quoting to fold the
+  // Conductor's skim into the quoted output (mirrors `Conductor._swap`).
+  {
+    type: "function",
+    name: "hostFeeBps",
+    stateMutability: "view",
+    inputs: [{ name: "pool", type: "address" }],
+    outputs: [{ name: "", type: "uint16" }],
+  },
+  {
+    type: "function",
+    name: "protocolFeeBps",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint16" }],
+  },
+  {
+    type: "function",
+    name: "wbtc",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "address" }],
+  },
+  {
+    type: "function",
+    name: "usdb",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "address" }],
+  },
 ] as const;

--- a/src/execution/abis/uniswapV3.ts
+++ b/src/execution/abis/uniswapV3.ts
@@ -50,3 +50,37 @@ export const uniswapV3PoolAbi = [
     outputs: [{ name: "", type: "address" }],
   },
 ] as const;
+
+/**
+ * Uniswap V3 `QuoterV2`. `quoteExactInputSingle` is `nonpayable` on-chain (it
+ * runs the swap and reverts to unwind) but is invoked read-only via `eth_call`;
+ * declaring it `view` here lets viem's `readContract` call it without sending a
+ * transaction. The simulated revert surfaces as a thrown error the caller maps
+ * to "no pool / insufficient liquidity".
+ */
+export const uniswapV3QuoterV2Abi = [
+  {
+    type: "function",
+    name: "quoteExactInputSingle",
+    stateMutability: "view",
+    inputs: [
+      {
+        name: "params",
+        type: "tuple",
+        components: [
+          { name: "tokenIn", type: "address" },
+          { name: "tokenOut", type: "address" },
+          { name: "amountIn", type: "uint256" },
+          { name: "fee", type: "uint24" },
+          { name: "sqrtPriceLimitX96", type: "uint160" },
+        ],
+      },
+    ],
+    outputs: [
+      { name: "amountOut", type: "uint256" },
+      { name: "sqrtPriceX96After", type: "uint160" },
+      { name: "initializedTicksCrossed", type: "uint32" },
+      { name: "gasEstimate", type: "uint256" },
+    ],
+  },
+] as const;

--- a/src/trading/client.spec.ts
+++ b/src/trading/client.spec.ts
@@ -535,26 +535,18 @@ describe("TradingClient.swap — minAmountOut unit handling", () => {
       wbtcAddress: WBTC,
     });
 
-    // Gateway works in WBTC wei; minAmountOut is a whole-sat-multiple wei.
-    const gatewayMinWei = 49_750_000n * WEI_PER_SAT;
-    global.fetch = jest.fn(async (input: any) => {
-      const url = typeof input === "string" ? input : (input.url ?? "");
-      if (url.endsWith("/api/v1/swap/quote")) {
-        return new Response(
-          JSON.stringify({
-            amountOut: (50_000_000n * WEI_PER_SAT).toString(),
-            minAmountOut: gatewayMinWei.toString(),
-            sqrtPriceX96After: "0",
-            feeTier: 3000,
-            slippageBps: 50,
-            conductorFeeBps: 0,
-            conductorFeeAmount: "0",
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } }
-        );
-      }
-      throw new Error(`unexpected fetch in test: ${url}`);
-    }) as unknown as typeof fetch;
+    // quote() computes the swap client-side in WBTC wei; stub that core (its
+    // own logic is covered in quote.spec.ts) and assert the wei->sat handoff
+    // from quote() into swap().
+    const minWei = 49_750_000n * WEI_PER_SAT;
+    jest.spyOn(amm as any, "computeSwapQuote").mockResolvedValue({
+      amountOut: (50_000_000n * WEI_PER_SAT).toString(),
+      minAmountOut: minWei.toString(),
+      feeTier: 3000,
+      slippageBps: 50,
+      conductorFeeBps: 0,
+      conductorFeeAmount: "0",
+    });
 
     const q = await amm.quote({
       assetInAddress: TOKEN_A,
@@ -577,6 +569,6 @@ describe("TradingClient.swap — minAmountOut unit handling", () => {
     });
     const decoded = decodeSigned(sign);
     expect(decoded.functionName).toBe("swapAndWithdrawBTC");
-    expect(decoded.args[3]).toBe(gatewayMinWei);
+    expect(decoded.args[3]).toBe(minWei);
   });
 });

--- a/src/trading/client.ts
+++ b/src/trading/client.ts
@@ -37,8 +37,11 @@ import {
   hexToBigInt,
   isAddress,
   keccak256,
+  BaseError,
+  ContractFunctionRevertedError,
   type Address,
   type Hex,
+  type PublicClient,
 } from "viem";
 import type { ExecutionClient } from "../execution/client";
 import type {
@@ -50,6 +53,21 @@ import type {
 import { conductorAbi } from "../execution/abis/conductor";
 import { nonfungiblePositionManagerAbi } from "../execution/abis/nonfungiblePositionManager";
 import { fetchNonce, fetchAllowance, fetchEip1559Fees } from "../execution/evm";
+import { getPoolAddress } from "../execution/pool";
+import {
+  uniswapV3PoolAbi,
+  uniswapV3QuoterV2Abi,
+} from "../execution/abis/uniswapV3";
+import {
+  applySlippage,
+  conductorSkim,
+  effectiveSwapInput,
+  priceImpactBps,
+  resolveFeeAsset,
+  DEFAULT_SLIPPAGE_BPS,
+  MAX_FEE_RATE_BPS,
+  UINT24_MAX,
+} from "./quote-math";
 import {
   decodeSparkHumanReadableTokenIdentifier,
   type SparkHumanReadableTokenIdentifier,
@@ -125,9 +143,6 @@ const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const DEFAULT_SWAP_GAS_LIMIT = 1_000_000n;
 const DEFAULT_APPROVE_GAS_LIMIT = 100_000n;
 const DEFAULT_LP_GAS_LIMIT = 1_500_000n;
-
-/** Timeout for the read-only gateway swap-quote HTTP request. */
-const QUOTE_TIMEOUT_MS = 10_000;
 
 /** Conversion factor: 1 sat = 10^10 wei on Flashnet's EVM. */
 const WEI_PER_SAT = 10_000_000_000n;
@@ -209,6 +224,12 @@ export interface TradingConfig {
    * A trading-stack address, so it lives here rather than on `NetworkInfo`.
    */
   factoryAddress?: string;
+  /**
+   * Uniswap V3 `QuoterV2` address. Required by {@link TradingClient.quote},
+   * which reads `quoteExactInputSingle` directly over RPC (the gateway no
+   * longer proxies quotes). A trading-stack address, like `factoryAddress`.
+   */
+  quoterV2Address?: string;
   /**
    * NonfungiblePositionManager (NPM) address. Required for every
    * liquidity-management method: read paths (`getPosition`, `listPositions`)
@@ -395,12 +416,15 @@ export interface QuoteResult {
   conductorFeeAsset?: string;
 }
 
-/** Raw shape of the gateway `POST /api/v1/swap/quote` response. */
-interface GatewaySwapQuoteResponse {
+/**
+ * Client-side computed swap quote, in `tokenIn`/`tokenOut` base units. Replaces
+ * the old gateway-proxied response shape; {@link TradingClient.quote} applies
+ * the BTC↔sats glue on top.
+ */
+interface ComputedSwapQuote {
   amountOut: string;
   minAmountOut: string;
   priceImpactBps?: number;
-  sqrtPriceX96After: string;
   feeTier: number;
   slippageBps: number;
   conductorFeeBps: number;
@@ -807,10 +831,10 @@ export class TradingClient {
   }
 
   /**
-   * Fetch a pre-trade quote for a single-pool swap. The gateway reads the
-   * on-chain Uniswap V3 `QuoterV2`; this returns the estimated output, a
-   * slippage-adjusted `minAmountOut` you can pass straight to {@link swap},
-   * and the pool price impact.
+   * Fetch a pre-trade quote for a single-pool swap. Reads the on-chain Uniswap
+   * V3 `QuoterV2` directly over RPC, folds in the Conductor's fee skim, and
+   * returns the estimated output, a slippage-adjusted `minAmountOut` you can
+   * pass straight to {@link swap}, and the pool price impact.
    *
    * BTC legs are quoted against the configured WBTC pool token: a `"btc"`
    * input amount (sats) is converted to WBTC wei for the quote, and a
@@ -818,9 +842,8 @@ export class TradingClient {
    * WBTC and withdraws sats, flooring sub-sat dust). Either `"btc"` leg
    * requires `wbtcAddress` in {@link TradingConfig}.
    *
-   * Requires the gateway to expose `POST /api/v1/swap/quote` with a QuoterV2
-   * address configured; if it does not, the gateway returns 503 and this
-   * throws.
+   * Requires `quoterV2Address` (and, since the Conductor fee is always folded
+   * in, `factoryAddress`) in {@link TradingConfig}; throws if either is unset.
    */
   async quote(params: QuoteParams): Promise<QuoteResult> {
     const isBtcIn = params.assetInAddress.toLowerCase() === "btc";
@@ -870,24 +893,16 @@ export class TradingClient {
     const tokenOut = isBtcOut
       ? this.requireWbtcAddress()
       : params.assetOutAddress;
-    // BTC input is denominated in sats; the WBTC pool leg is in wei. Forward
-    // the normalized decimal for token legs too, so a quirky-but-valid input
-    // reaches the gateway canonicalized.
-    const amountIn = isBtcIn
-      ? (amountInRaw * WEI_PER_SAT).toString()
-      : amountInRaw.toString();
+    // BTC input is denominated in sats; the WBTC pool leg is in wei.
+    const amountIn = isBtcIn ? amountInRaw * WEI_PER_SAT : amountInRaw;
 
-    const res = await this.postSwapQuote({
+    const res = await this.computeSwapQuote({
       tokenIn,
       tokenOut,
       fee: params.fee,
       amountIn,
-      ...(params.slippageBps !== undefined
-        ? { slippageBps: params.slippageBps }
-        : {}),
-      ...(params.integratorBps !== undefined
-        ? { integratorBps: params.integratorBps }
-        : {}),
+      slippageBps: params.slippageBps,
+      integratorBps: params.integratorBps,
     });
 
     // Don't blindly trust the gateway with a value the caller will use as an
@@ -976,61 +991,234 @@ export class TradingClient {
     return this.config.wbtcAddress;
   }
 
-  /** POST the gateway swap-quote endpoint and parse its response. */
-  private async postSwapQuote(body: {
+  /**
+   * Compute a single-pool swap quote client-side, in `tokenIn`/`tokenOut` base
+   * units: resolve the pool, fold in the Conductor fee skim, read
+   * `QuoterV2.quoteExactInputSingle` over RPC, and derive the slippage floor
+   * plus a best-effort price impact. Ported from the gateway's removed
+   * `quote.rs`; the fee/slippage math lives in `./quote-math`.
+   */
+  private async computeSwapQuote(input: {
     tokenIn: string;
     tokenOut: string;
     fee: number;
-    amountIn: string;
+    amountIn: bigint;
     slippageBps?: number;
     integratorBps?: number;
-  }): Promise<GatewaySwapQuoteResponse> {
-    const { gatewayUrl } = this.execClient.getConfig();
-    const url = `${gatewayUrl}/api/v1/swap/quote`;
+  }): Promise<ComputedSwapQuote> {
+    const { tokenIn, tokenOut, fee, amountIn } = input;
+    const slippageBps = input.slippageBps ?? DEFAULT_SLIPPAGE_BPS;
+    const integratorBps = BigInt(input.integratorBps ?? 0);
 
-    // Bound the whole request (including the body read) so a slow or stalled
-    // gateway can't hang quote() indefinitely.
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), QUOTE_TIMEOUT_MS);
+    if (!isAddress(tokenIn) || !isAddress(tokenOut)) {
+      throw new Error(
+        "quote: tokenIn and tokenOut must be 0x-prefixed addresses."
+      );
+    }
+    if (tokenIn.toLowerCase() === tokenOut.toLowerCase()) {
+      throw new Error("quote: tokenIn and tokenOut must differ.");
+    }
+    if (!Number.isInteger(fee) || fee < 0 || fee > UINT24_MAX) {
+      throw new Error(
+        "quote: fee must be a uint24 tier (e.g. 500, 3000, 10000)."
+      );
+    }
+
+    const quoter = this.config.quoterV2Address;
+    if (!quoter) {
+      throw new Error(
+        "quote: quoterV2Address is not configured in TradingConfig — the " +
+          "Uniswap V3 QuoterV2 the SDK reads quotes from."
+      );
+    }
+    const conductor = this.config.conductorAddress;
+    const factory = this.config.factoryAddress;
+    // The Conductor host fee is keyed by pool address, so a fee-aware quote
+    // needs the factory to resolve the pool (mirrors the gateway's 503).
+    if (conductor && !factory) {
+      throw new Error(
+        "quote: fee-aware quotes require factoryAddress in TradingConfig to " +
+          "resolve the pool for the Conductor host fee."
+      );
+    }
+
+    const rpcUrl = this.execClient.getConfig().rpcUrl;
+    const client = getClient(rpcUrl);
+
+    // Resolve the pool when a factory is configured; a configured factory that
+    // resolves no pool is a hard error.
+    const pool = factory
+      ? await getPoolAddress(rpcUrl, factory, tokenIn, tokenOut, fee)
+      : null;
+    if (factory && !pool) {
+      throw new Error("quote: no pool for the given tokenIn/tokenOut/fee.");
+    }
+
+    // Conductor fee. With no Conductor address the quote is the raw Uniswap
+    // output and conductorFeeBps is 0.
+    let totalFeeBps = 0n;
+    let feeAsset: string | undefined;
+    if (conductor && pool) {
+      ({ totalFeeBps, feeAsset } = await this.resolveConductorFee(
+        client,
+        conductor,
+        pool,
+        integratorBps,
+        tokenIn,
+        tokenOut
+      ));
+    }
+
+    // Input-side skim reduces the amount actually swapped (mirrors
+    // Conductor._swap); output-side skim is taken off the gross output.
+    const inputSide =
+      feeAsset !== undefined &&
+      feeAsset.toLowerCase() === tokenIn.toLowerCase();
+    const quoterAmount = effectiveSwapInput(amountIn, totalFeeBps, inputSide);
+    const inputFee = amountIn - quoterAmount;
+
+    const { grossOut, sqrtAfter } = await this.quoteExactInputSingle(
+      client,
+      quoter,
+      { tokenIn, tokenOut, fee, amountIn: quoterAmount }
+    );
+
+    const outputFee = inputSide ? 0n : conductorSkim(grossOut, totalFeeBps);
+    const netOut = grossOut - outputFee;
+    const feeAmount = inputSide ? inputFee : outputFee;
+
+    return {
+      amountOut: netOut.toString(),
+      minAmountOut: applySlippage(netOut, slippageBps).toString(),
+      priceImpactBps: pool
+        ? await this.poolPriceImpact(client, pool, sqrtAfter)
+        : undefined,
+      feeTier: fee,
+      slippageBps,
+      conductorFeeBps: Number(totalFeeBps),
+      conductorFeeAmount: feeAmount.toString(),
+      conductorFeeAsset: feeAsset,
+    };
+  }
+
+  /**
+   * Read `hostFeeBps(pool)` + `protocolFeeBps()`, add the integrator bps, and
+   * resolve the fee asset (only when a fee applies). Each on-chain component is
+   * capped at `MAX_FEE_RATE_BPS`; a larger value is corrupt upstream data and
+   * is rejected rather than folded into the skim.
+   */
+  private async resolveConductorFee(
+    client: PublicClient,
+    conductor: string,
+    pool: string,
+    integratorBps: bigint,
+    tokenIn: string,
+    tokenOut: string
+  ): Promise<{ totalFeeBps: bigint; feeAsset?: string }> {
+    const address = conductor as Address;
+    const [hostBps, protocolBps] = await Promise.all([
+      client.readContract({
+        address,
+        abi: conductorAbi,
+        functionName: "hostFeeBps",
+        args: [pool as Address],
+      }),
+      client.readContract({
+        address,
+        abi: conductorAbi,
+        functionName: "protocolFeeBps",
+      }),
+    ]);
+    const totalFeeBps =
+      this.requireBoundedFeeBps(hostBps, "hostFeeBps") +
+      this.requireBoundedFeeBps(protocolBps, "protocolFeeBps") +
+      integratorBps;
+    if (totalFeeBps === 0n) {
+      return { totalFeeBps, feeAsset: undefined };
+    }
+    const [wbtc, usdb] = await Promise.all([
+      client.readContract({ address, abi: conductorAbi, functionName: "wbtc" }),
+      client.readContract({ address, abi: conductorAbi, functionName: "usdb" }),
+    ]);
+    return {
+      totalFeeBps,
+      feeAsset: resolveFeeAsset(tokenIn, tokenOut, wbtc, usdb),
+    };
+  }
+
+  /** Widen a uint16 fee-bps read to bigint, rejecting anything above the cap. */
+  private requireBoundedFeeBps(raw: number, field: string): bigint {
+    const bps = BigInt(raw);
+    if (bps > MAX_FEE_RATE_BPS) {
+      throw new Error(
+        `quote: Conductor ${field}=${raw} exceeds the protocol maximum ` +
+          `of ${MAX_FEE_RATE_BPS}.`
+      );
+    }
+    return bps;
+  }
+
+  /**
+   * Read `QuoterV2.quoteExactInputSingle` over RPC (an `eth_call` to a
+   * nonpayable function). A simulated revert means no pool / insufficient
+   * liquidity; any other error (transport/node) propagates.
+   */
+  private async quoteExactInputSingle(
+    client: PublicClient,
+    quoter: string,
+    p: { tokenIn: string; tokenOut: string; fee: number; amountIn: bigint }
+  ): Promise<{ grossOut: bigint; sqrtAfter: bigint }> {
     try {
-      let resp: Response;
-      try {
-        resp = await fetch(url, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(body),
-          signal: controller.signal,
-        });
-      } catch (err) {
-        const reason =
-          err instanceof Error && err.name === "AbortError"
-            ? `timed out after ${QUOTE_TIMEOUT_MS}ms`
-            : err instanceof Error
-              ? err.message
-              : String(err);
+      const result = await client.readContract({
+        address: quoter as Address,
+        abi: uniswapV3QuoterV2Abi,
+        functionName: "quoteExactInputSingle",
+        args: [
+          {
+            tokenIn: p.tokenIn as Address,
+            tokenOut: p.tokenOut as Address,
+            amountIn: p.amountIn,
+            fee: p.fee,
+            sqrtPriceLimitX96: 0n,
+          },
+        ],
+      });
+      return { grossOut: result[0], sqrtAfter: result[1] };
+    } catch (err) {
+      const isRevert =
+        err instanceof BaseError &&
+        (err.walk((e) => e instanceof ContractFunctionRevertedError) !==
+          null ||
+          (err.shortMessage ?? err.message).toLowerCase().includes("revert"));
+      if (isRevert) {
         throw new Error(
-          `quote: could not reach the gateway quote endpoint at ${url}: ${reason}`
+          "quote: no pool or insufficient liquidity for the given " +
+            "tokenIn/tokenOut/fee."
         );
       }
+      throw err;
+    }
+  }
 
-      if (!resp.ok) {
-        // The gateway returns RFC-7807 problem+json; surface its detail.
-        let detail = `HTTP ${resp.status}`;
-        try {
-          const problem = (await resp.json()) as {
-            detail?: string;
-            title?: string;
-          };
-          detail = problem.detail ?? problem.title ?? detail;
-        } catch {
-          // Non-JSON error body — keep the status-only detail.
-        }
-        throw new Error(`quote: gateway rejected the request: ${detail}`);
-      }
-
-      return (await resp.json()) as GatewaySwapQuoteResponse;
-    } finally {
-      clearTimeout(timer);
+  /**
+   * Best-effort pool mid-price move (bps) from the pre-trade `slot0` and the
+   * post-swap sqrt price. Any read failure degrades to `undefined` rather than
+   * failing the quote.
+   */
+  private async poolPriceImpact(
+    client: PublicClient,
+    pool: string,
+    sqrtAfter: bigint
+  ): Promise<number | undefined> {
+    try {
+      const slot0 = await client.readContract({
+        address: pool as Address,
+        abi: uniswapV3PoolAbi,
+        functionName: "slot0",
+      });
+      return priceImpactBps(slot0[0], sqrtAfter);
+    } catch {
+      return undefined;
     }
   }
 

--- a/src/trading/quote-math.ts
+++ b/src/trading/quote-math.ts
@@ -1,0 +1,96 @@
+/**
+ * Pure fee / slippage / price-impact math for client-side swap quoting.
+ *
+ * Ported verbatim from the gateway's removed `quote.rs` handler (the
+ * authoritative spec). All amounts are `bigint`; integer division floors,
+ * matching the Rust `U256` truncating division the gateway used. Keep these
+ * free of RPC/viem so they stay unit-testable in isolation.
+ */
+
+/** Denominator for basis-point math. */
+export const BPS_DENOMINATOR = 10_000n;
+/**
+ * Per-component fee cap (basis points), mirroring the Conductor's
+ * `MAX_FEE_RATE_BPS`. Bounds each of `hostFeeBps`, `protocolFeeBps`, and
+ * `integratorBps`: a larger value either reverts on-chain (integrator) or is
+ * corrupt upstream data (host/protocol).
+ */
+export const MAX_FEE_RATE_BPS = 1_000n;
+/** Default slippage tolerance (basis points) when the caller omits one. */
+export const DEFAULT_SLIPPAGE_BPS = 50;
+/** Inclusive upper bound for the Uniswap V3 `fee` tier (uint24 max). */
+export const UINT24_MAX = 0x00ff_ffff;
+
+/**
+ * The Conductor fee skim, mirroring `Conductor._swap`:
+ * `fee = amount * totalBps / (10_000 + totalBps)` (floored).
+ */
+export function conductorSkim(amount: bigint, totalFeeBps: bigint): bigint {
+  if (totalFeeBps === 0n) return 0n;
+  return (amount * totalFeeBps) / (BPS_DENOMINATOR + totalFeeBps);
+}
+
+/**
+ * The amount actually swapped on Uniswap after the Conductor's input-side skim.
+ * Output-side fees don't touch the input, so the full amount is swapped.
+ */
+export function effectiveSwapInput(
+  amountIn: bigint,
+  totalFeeBps: bigint,
+  inputSide: boolean
+): bigint {
+  return inputSide ? amountIn - conductorSkim(amountIn, totalFeeBps) : amountIn;
+}
+
+/**
+ * Resolve the fee asset, mirroring `Conductor._feeAsset`: WBTC if either leg is
+ * WBTC, else USDB if either leg is USDB, else the output token. Addresses are
+ * compared case-insensitively since they arrive from RPC/params with mixed
+ * casing; the returned value preserves the caller's casing of the chosen leg.
+ */
+export function resolveFeeAsset(
+  tokenIn: string,
+  tokenOut: string,
+  wbtc: string,
+  usdb: string
+): string {
+  const ti = tokenIn.toLowerCase();
+  const to = tokenOut.toLowerCase();
+  const w = wbtc.toLowerCase();
+  const u = usdb.toLowerCase();
+  if (ti === w || to === w) return wbtc;
+  if (ti === u || to === u) return usdb;
+  return tokenOut;
+}
+
+/**
+ * Apply a basis-point slippage haircut to an output amount (floored).
+ * `slippageBps` is clamped to `[0, 10_000]`, so 100% slippage floors at zero.
+ */
+export function applySlippage(amountOut: bigint, slippageBps: number): bigint {
+  const clamped = Math.min(Math.max(Math.trunc(slippageBps), 0), 10_000);
+  return (amountOut * (BPS_DENOMINATOR - BigInt(clamped))) / BPS_DENOMINATOR;
+}
+
+/**
+ * Pool mid-price move in basis points from the sqrt prices before/after the
+ * swap (`price = sqrtPrice^2`): `|1 - (after/before)^2| * 10_000`, rounded and
+ * clamped to a uint32. An advisory UX figure computed in float — not a
+ * settlement value; the exact amounts elsewhere are integer-precise. Returns
+ * `undefined` when the pre-trade price is zero or unusable.
+ */
+export function priceImpactBps(
+  sqrtBefore: bigint,
+  sqrtAfter: bigint
+): number | undefined {
+  if (sqrtBefore <= 0n) return undefined;
+  const before = Number(sqrtBefore);
+  const after = Number(sqrtAfter);
+  if (!Number.isFinite(before) || !Number.isFinite(after) || before === 0) {
+    return undefined;
+  }
+  const ratio = after / before;
+  const impact = Math.abs(1 - ratio * ratio) * Number(BPS_DENOMINATOR);
+  if (!Number.isFinite(impact)) return undefined;
+  return Math.min(Math.max(Math.round(impact), 0), 0xffff_ffff);
+}

--- a/src/trading/quote.spec.ts
+++ b/src/trading/quote.spec.ts
@@ -1,17 +1,29 @@
 import { secp256k1 } from "@noble/curves/secp256k1";
+import { BaseError, zeroAddress } from "viem";
 import { ExecutionClient } from "../execution/client";
 import type { SparkWalletInput } from "../execution/spark-evm-account";
 import { TradingClient } from "./client";
+import {
+  applySlippage,
+  conductorSkim,
+  effectiveSwapInput,
+  priceImpactBps,
+  resolveFeeAsset,
+} from "./quote-math";
+
+// `quote()` reads the chain via `getClient(rpcUrl).readContract` (directly for
+// the QuoterV2 / Conductor / pool reads, and transitively through
+// `getPoolAddress`). Mock the rpc module so a single `readContract` stub drives
+// every read; dispatch on `functionName`.
+const mockReadContract = jest.fn();
+jest.mock("../execution/rpc", () => ({
+  getClient: jest.fn(() => ({ readContract: mockReadContract })),
+}));
 
 // Deterministic test key — private key = 1 (well-known test scalar).
 const TEST_KEY = new Uint8Array(32);
 TEST_KEY[31] = 1;
 
-/**
- * Minimal SparkWallet for constructing ExecutionClient. `quote()` never
- * touches the wallet (it only reads `getConfig().gatewayUrl` and fetches),
- * so only the signer the constructor expects needs to be present.
- */
 function mockWallet(): SparkWalletInput {
   const pubkey = secp256k1.getPublicKey(TEST_KEY, true);
   return {
@@ -35,162 +47,188 @@ const EXEC_CONFIG = {
   chainId: 21022,
 };
 
-const WBTC = "0x5555555555555555555555555555555555555555";
-const AMM_CONFIG = {
-  conductorAddress: "0x1111111111111111111111111111111111111111",
-  wbtcAddress: WBTC,
-};
-const TOKEN_A = "0x4444444444444444444444444444444444444444";
+const CONDUCTOR = "0x1111111111111111111111111111111111111111";
 const TOKEN_B = "0x2222222222222222222222222222222222222222";
+const TOKEN_A = "0x4444444444444444444444444444444444444444";
+const WBTC = "0x5555555555555555555555555555555555555555";
+const FACTORY = "0x6666666666666666666666666666666666666666";
+const QUOTER = "0x7777777777777777777777777777777777777777";
+const USDB = "0x8888888888888888888888888888888888888888";
+const POOL = "0x9999999999999999999999999999999999999999";
 
 const WEI_PER_SAT = 10_000_000_000n;
 
-const GATEWAY_OK = {
-  amountOut: "994035",
-  minAmountOut: "989065",
-  priceImpactBps: 12,
-  sqrtPriceX96After: "79228162514264337593543950336",
-  feeTier: 3000,
-  slippageBps: 50,
-  conductorFeeBps: 0,
-  conductorFeeAmount: "0",
+/** Full trading config: every address quote() needs is present. */
+const FULL_CONFIG = {
+  conductorAddress: CONDUCTOR,
+  wbtcAddress: WBTC,
+  factoryAddress: FACTORY,
+  quoterV2Address: QUOTER,
 };
 
-interface CapturedRequest {
-  url: string;
-  body: Record<string, unknown> | undefined;
+interface ReadFixture {
+  pool?: string;
+  hostBps?: number;
+  protocolBps?: number;
+  wbtc?: string;
+  usdb?: string;
+  grossOut?: bigint;
+  sqrtAfter?: bigint;
+  sqrtBefore?: bigint;
+  quoterRevert?: boolean;
+  slot0Throw?: boolean;
 }
 
-/**
- * Stub `fetch` to answer the swap-quote endpoint with `response`/`status`
- * and record every request so tests can assert the forwarded body.
- */
-function stubQuoteFetch(
-  response: Record<string, unknown>,
-  status = 200
-): CapturedRequest[] {
-  const calls: CapturedRequest[] = [];
-  global.fetch = jest.fn(async (input: any, init?: any) => {
-    const url = typeof input === "string" ? input : (input.url ?? "");
-    calls.push({
-      url,
-      body: init?.body ? JSON.parse(init.body) : undefined,
-    });
-    if (url.endsWith("/api/v1/swap/quote")) {
-      return new Response(JSON.stringify(response), {
-        status,
-        headers: { "Content-Type": "application/json" },
-      });
+/** Drive `mockReadContract` from a per-test fixture, dispatching on call. */
+function configureReads(f: ReadFixture = {}): void {
+  mockReadContract.mockImplementation((call: { functionName: string }) => {
+    switch (call.functionName) {
+      case "getPool":
+        return f.pool ?? POOL;
+      case "hostFeeBps":
+        return f.hostBps ?? 0;
+      case "protocolFeeBps":
+        return f.protocolBps ?? 0;
+      case "wbtc":
+        return f.wbtc ?? WBTC;
+      case "usdb":
+        return f.usdb ?? USDB;
+      case "slot0":
+        if (f.slot0Throw) throw new Error("slot0 read failed");
+        return [f.sqrtBefore ?? f.sqrtAfter ?? 1n, 0, 0, 0, 0, 0, true];
+      case "quoteExactInputSingle":
+        if (f.quoterRevert) throw new BaseError("execution reverted");
+        return [f.grossOut ?? 1_000_000n, f.sqrtAfter ?? 1n, 0, 0n];
+      default:
+        throw new Error(`unexpected read: ${call.functionName}`);
     }
-    throw new Error(`unexpected fetch in test: ${url}`);
-  }) as unknown as typeof fetch;
-  return calls;
+  });
 }
 
-function newAmm(config: Record<string, unknown> = AMM_CONFIG): TradingClient {
+/** The `amountIn` the QuoterV2 was actually asked to quote. */
+function quoterAmountIn(): bigint {
+  const call = mockReadContract.mock.calls.find(
+    (c) => c[0]?.functionName === "quoteExactInputSingle"
+  );
+  return call?.[0]?.args?.[0]?.amountIn as bigint;
+}
+
+function newAmm(config: Record<string, unknown> = FULL_CONFIG): TradingClient {
   return new TradingClient(
     new ExecutionClient(mockWallet(), EXEC_CONFIG),
-    config as any
+    config as never
   );
 }
 
-// Capture the real fetch so each test fully undoes `global.fetch = jest.fn`.
-// `jest.restoreAllMocks()` only restores `jest.spyOn` mocks, not direct
-// global assignments, so a test that forgot to stub would otherwise inherit
-// a stale mock from a previous run.
-const originalFetch = global.fetch;
 afterEach(() => {
-  jest.restoreAllMocks();
-  global.fetch = originalFetch;
+  mockReadContract.mockReset();
 });
 
-describe("TradingClient.quote", () => {
-  it("maps a token→token quote and forwards the request verbatim", async () => {
-    const calls = stubQuoteFetch(GATEWAY_OK);
-    const amm = newAmm();
+// ── Pure math, ported verbatim from the gateway's removed quote.rs tests ──────
 
-    const q = await amm.quote({
-      assetInAddress: TOKEN_A,
-      assetOutAddress: TOKEN_B,
-      amountIn: "1000000",
-      fee: 3000,
-      slippageBps: 50,
-    });
-
-    expect(q.amountOut).toBe("994035");
-    expect(q.minAmountOut).toBe("989065");
-    expect(q.priceImpactBps).toBe(12);
-    expect(q.slippageBps).toBe(50);
-    expect(q.fee).toBe(3000);
-
-    expect(calls).toHaveLength(1);
-    expect(calls[0]?.url).toBe("http://localhost:8080/api/v1/swap/quote");
-    expect(calls[0]?.body).toEqual({
-      tokenIn: TOKEN_A,
-      tokenOut: TOKEN_B,
-      fee: 3000,
-      amountIn: "1000000",
-      slippageBps: 50,
-    });
+describe("quote-math", () => {
+  it("applySlippage applies a bps haircut (floored)", () => {
+    expect(applySlippage(1_000_000n, 50)).toBe(995_000n);
+    expect(applySlippage(1234n, 0)).toBe(1234n); // no-op
+    expect(applySlippage(1234n, 10_000)).toBe(0n); // 100% floors to zero
   });
 
-  it("omits slippageBps from the request when the caller omits it", async () => {
-    const calls = stubQuoteFetch(GATEWAY_OK);
-    const amm = newAmm();
-
-    await amm.quote({
-      assetInAddress: TOKEN_A,
-      assetOutAddress: TOKEN_B,
-      amountIn: "1000000",
-      fee: 3000,
-    });
-
-    expect(calls[0]?.body).not.toHaveProperty("slippageBps");
+  it("priceImpactBps reflects the sqrt-price move", () => {
+    const p = 79_228_162_514_264_337_593_543_950_336n; // 2^96
+    expect(priceImpactBps(p, p)).toBe(0); // unchanged price
+    // after/before = 0.995 -> price ratio 0.990025 -> ~99.75 bps -> 100.
+    expect(priceImpactBps(1_000_000n, 995_000n)).toBe(100);
+    expect(priceImpactBps(0n, 1n)).toBeUndefined(); // unusable pre-trade price
   });
 
-  it("converts a BTC input from sats to WBTC wei and maps it to wbtcAddress", async () => {
-    const calls = stubQuoteFetch(GATEWAY_OK);
-    const amm = newAmm();
-
-    await amm.quote({
-      assetInAddress: "btc",
-      assetOutAddress: TOKEN_B,
-      amountIn: "250000",
-      fee: 3000,
-    });
-
-    expect(calls[0]?.body?.tokenIn).toBe(WBTC);
-    expect(calls[0]?.body?.tokenOut).toBe(TOKEN_B);
-    expect(calls[0]?.body?.amountIn).toBe((250000n * WEI_PER_SAT).toString());
+  it("conductorSkim matches `amount * bps / (10_000 + bps)`", () => {
+    expect(conductorSkim(10_030n, 30n)).toBe(30n);
+    expect(conductorSkim(1_000_000n, 0n)).toBe(0n);
+    expect(conductorSkim(1_030_000n, 300n)).toBe(30_000n);
   });
 
-  it("converts a BTC output from WBTC wei back to whole sats (flooring dust)", async () => {
-    // 12345 sats + 7 wei of sub-sat dust; min is a clean 12000 sats.
-    const weiOut = (12345n * WEI_PER_SAT + 7n).toString();
-    const weiMin = (12000n * WEI_PER_SAT).toString();
-    const calls = stubQuoteFetch({
-      ...GATEWAY_OK,
-      amountOut: weiOut,
-      minAmountOut: weiMin,
-    });
-    const amm = newAmm();
+  it("resolveFeeAsset is WBTC > USDB > tokenOut", () => {
+    expect(resolveFeeAsset(WBTC, TOKEN_A, WBTC, USDB)).toBe(WBTC);
+    expect(resolveFeeAsset(TOKEN_A, WBTC, WBTC, USDB)).toBe(WBTC);
+    expect(resolveFeeAsset(USDB, TOKEN_A, WBTC, USDB)).toBe(USDB);
+    expect(resolveFeeAsset(TOKEN_A, USDB, WBTC, USDB)).toBe(USDB);
+    expect(resolveFeeAsset(TOKEN_A, TOKEN_B, WBTC, USDB)).toBe(TOKEN_B);
+  });
 
-    const q = await amm.quote({
-      assetInAddress: TOKEN_A,
-      assetOutAddress: "btc",
-      amountIn: "1000000",
-      fee: 3000,
-    });
+  it("effectiveSwapInput reduces only on the input side", () => {
+    expect(effectiveSwapInput(10_030n, 30n, true)).toBe(10_000n);
+    expect(effectiveSwapInput(10_030n, 30n, false)).toBe(10_030n);
+    expect(effectiveSwapInput(10_030n, 0n, true)).toBe(10_030n);
+  });
+});
 
-    expect(calls[0]?.body?.tokenOut).toBe(WBTC);
-    expect(q.amountOut).toBe("12345");
-    expect(q.minAmountOut).toBe("12000");
+// ── quote() input validation (throws before any RPC) ─────────────────────────
+
+describe("TradingClient.quote — validation", () => {
+  it("rejects BTC -> BTC", async () => {
+    await expect(
+      newAmm().quote({
+        assetInAddress: "btc",
+        assetOutAddress: "btc",
+        amountIn: "1000",
+        fee: 3000,
+      })
+    ).rejects.toThrow(/BTC → BTC/);
+    expect(mockReadContract).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-positive amountIn", async () => {
+    await expect(
+      newAmm().quote({
+        assetInAddress: TOKEN_A,
+        assetOutAddress: TOKEN_B,
+        amountIn: "0",
+        fee: 3000,
+      })
+    ).rejects.toThrow(/greater than zero/);
+  });
+
+  it("rejects a non-base-10 amountIn", async () => {
+    await expect(
+      newAmm().quote({
+        assetInAddress: TOKEN_A,
+        assetOutAddress: TOKEN_B,
+        amountIn: "0x10",
+        fee: 3000,
+      })
+    ).rejects.toThrow(/base-10 integer/);
+  });
+
+  it("rejects out-of-range slippageBps", async () => {
+    await expect(
+      newAmm().quote({
+        assetInAddress: TOKEN_A,
+        assetOutAddress: TOKEN_B,
+        amountIn: "1000",
+        fee: 3000,
+        slippageBps: 10_001,
+      })
+    ).rejects.toThrow(/slippageBps/);
+  });
+
+  it("rejects out-of-range integratorBps", async () => {
+    await expect(
+      newAmm().quote({
+        assetInAddress: TOKEN_A,
+        assetOutAddress: TOKEN_B,
+        amountIn: "1000",
+        fee: 3000,
+        integratorBps: 1001,
+      })
+    ).rejects.toThrow(/integratorBps/);
   });
 
   it("requires wbtcAddress for a btc leg", async () => {
-    stubQuoteFetch(GATEWAY_OK);
-    const amm = newAmm({ conductorAddress: AMM_CONFIG.conductorAddress });
-
+    const amm = newAmm({
+      conductorAddress: CONDUCTOR,
+      factoryAddress: FACTORY,
+      quoterV2Address: QUOTER,
+    });
     await expect(
       amm.quote({
         assetInAddress: "btc",
@@ -201,292 +239,237 @@ describe("TradingClient.quote", () => {
     ).rejects.toThrow(/wbtcAddress/);
   });
 
-  it("rejects BTC → BTC", async () => {
-    stubQuoteFetch(GATEWAY_OK);
-    const amm = newAmm();
-
+  it("rejects identical tokenIn/tokenOut", async () => {
+    configureReads();
     await expect(
-      amm.quote({
-        assetInAddress: "btc",
-        assetOutAddress: "BTC",
+      newAmm().quote({
+        assetInAddress: TOKEN_A,
+        assetOutAddress: TOKEN_A,
         amountIn: "1000",
         fee: 3000,
       })
-    ).rejects.toThrow(/BTC → BTC/);
+    ).rejects.toThrow(/must differ/);
   });
 
-  it("rejects non-positive amountIn", async () => {
-    stubQuoteFetch(GATEWAY_OK);
-    const amm = newAmm();
-
+  it("throws when quoterV2Address is unconfigured", async () => {
+    const amm = newAmm({
+      conductorAddress: CONDUCTOR,
+      wbtcAddress: WBTC,
+      factoryAddress: FACTORY,
+    });
     await expect(
       amm.quote({
         assetInAddress: TOKEN_A,
         assetOutAddress: TOKEN_B,
-        amountIn: "0",
+        amountIn: "1000",
         fee: 3000,
       })
-    ).rejects.toThrow(/greater than zero/);
+    ).rejects.toThrow(/quoterV2Address is not configured/);
   });
 
-  it("rejects out-of-range slippageBps", async () => {
-    stubQuoteFetch(GATEWAY_OK);
-    const amm = newAmm();
-
+  it("throws when the Conductor is set without a factory", async () => {
+    const amm = newAmm({
+      conductorAddress: CONDUCTOR,
+      wbtcAddress: WBTC,
+      quoterV2Address: QUOTER,
+    });
     await expect(
       amm.quote({
         assetInAddress: TOKEN_A,
         assetOutAddress: TOKEN_B,
-        amountIn: "1000000",
+        amountIn: "1000",
         fee: 3000,
-        slippageBps: 10_001,
       })
-    ).rejects.toThrow(/slippageBps/);
-  });
-
-  it("surfaces the gateway problem+json detail on error", async () => {
-    stubQuoteFetch(
-      {
-        detail:
-          "no pool or insufficient liquidity for the given tokenIn/tokenOut/fee",
-      },
-      400
-    );
-    const amm = newAmm();
-
-    await expect(
-      amm.quote({
-        assetInAddress: TOKEN_A,
-        assetOutAddress: TOKEN_B,
-        amountIn: "1000000",
-        fee: 500,
-      })
-    ).rejects.toThrow(/no pool or insufficient liquidity/);
+    ).rejects.toThrow(/require factoryAddress/);
   });
 });
 
-describe("TradingClient.quote — input + response hardening", () => {
-  it("rejects amountIn that is not a base-10 integer", async () => {
-    stubQuoteFetch(GATEWAY_OK);
-    const amm = newAmm();
-    for (const bad of ["0x10", "1.5", "1e6", "100_000", "abc", "-5"]) {
-      await expect(
-        amm.quote({
-          assetInAddress: TOKEN_A,
-          assetOutAddress: TOKEN_B,
-          amountIn: bad,
-          fee: 3000,
-        })
-      ).rejects.toThrow(/amountIn/);
-    }
-  });
+// ── quote() computation (mocked reads) ───────────────────────────────────────
 
-  it("rejects a fractional slippageBps", async () => {
-    stubQuoteFetch(GATEWAY_OK);
-    const amm = newAmm();
-    await expect(
-      amm.quote({
-        assetInAddress: TOKEN_A,
-        assetOutAddress: TOKEN_B,
-        amountIn: "1000000",
-        fee: 3000,
-        slippageBps: 12.5,
-      })
-    ).rejects.toThrow(/integer between 0 and 10000/);
-  });
-
-  it("rejects a gateway minAmountOut greater than amountOut", async () => {
-    stubQuoteFetch({ ...GATEWAY_OK, amountOut: "1000", minAmountOut: "2000" });
-    const amm = newAmm();
-    await expect(
-      amm.quote({
-        assetInAddress: TOKEN_A,
-        assetOutAddress: TOKEN_B,
-        amountIn: "1000000",
-        fee: 3000,
-      })
-    ).rejects.toThrow(/minAmountOut greater than amountOut/);
-  });
-
-  it("rejects a non-numeric gateway amount", async () => {
-    stubQuoteFetch({ ...GATEWAY_OK, amountOut: "not-a-number" });
-    const amm = newAmm();
-    await expect(
-      amm.quote({
-        assetInAddress: TOKEN_A,
-        assetOutAddress: TOKEN_B,
-        amountIn: "1000000",
-        fee: 3000,
-      })
-    ).rejects.toThrow(/non-numeric amountOut/);
-  });
-
-  it("rejects when the gateway ignores the requested slippageBps", async () => {
-    stubQuoteFetch({ ...GATEWAY_OK, slippageBps: 25 });
-    const amm = newAmm();
-    await expect(
-      amm.quote({
-        assetInAddress: TOKEN_A,
-        assetOutAddress: TOKEN_B,
-        amountIn: "1000000",
-        fee: 3000,
-        slippageBps: 50,
-      })
-    ).rejects.toThrow(/gateway applied slippageBps=25/);
-  });
-
-  it("normalizes a missing or null priceImpactBps to undefined", async () => {
-    const omitted: Record<string, unknown> = { ...GATEWAY_OK };
-    delete omitted.priceImpactBps;
-    stubQuoteFetch(omitted);
-    const amm = newAmm();
-    const q1 = await amm.quote({
+describe("TradingClient.quote — computation", () => {
+  it("token -> token with no fee returns the raw QuoterV2 output", async () => {
+    configureReads({ grossOut: 1_000_000n, hostBps: 0, protocolBps: 0 });
+    const res = await newAmm().quote({
       assetInAddress: TOKEN_A,
+      assetOutAddress: TOKEN_B,
+      amountIn: "500000",
+      fee: 3000,
+    });
+    expect(res.amountOut).toBe("1000000");
+    expect(res.minAmountOut).toBe("995000"); // default 50 bps haircut
+    expect(res.conductorFeeBps).toBe(0);
+    expect(res.conductorFeeAmount).toBe("0");
+    expect(res.conductorFeeAsset).toBeUndefined();
+    expect(res.fee).toBe(3000);
+    expect(quoterAmountIn()).toBe(500_000n); // full input swapped
+  });
+
+  it("applies an output-side Conductor skim (fee asset = tokenOut)", async () => {
+    // tokenOut is the fee asset, so the skim comes off the gross output.
+    // total = 30 host + 0 protocol = 30 bps; skim(1_003_000, 30) = 3_000.
+    configureReads({
+      grossOut: 1_003_000n,
+      hostBps: 30,
+      protocolBps: 0,
+      wbtc: WBTC,
+      usdb: USDB,
+    });
+    const res = await newAmm().quote({
+      assetInAddress: TOKEN_A, // neither leg is WBTC/USDB -> fee asset = tokenOut
       assetOutAddress: TOKEN_B,
       amountIn: "1000000",
       fee: 3000,
+      slippageBps: 0,
     });
-    expect(q1.priceImpactBps).toBeUndefined();
+    expect(res.conductorFeeBps).toBe(30);
+    expect(res.conductorFeeAmount).toBe("3000"); // output-side skim
+    expect(res.conductorFeeAsset).toBe(TOKEN_B);
+    expect(res.amountOut).toBe("1000000"); // 1_003_000 - 3_000
+    expect(quoterAmountIn()).toBe(1_000_000n); // full input swapped
+  });
 
-    stubQuoteFetch({ ...GATEWAY_OK, priceImpactBps: null });
-    const q2 = await amm.quote({
-      assetInAddress: TOKEN_A,
+  it("applies an input-side skim and quotes the reduced input (fee asset = tokenIn)", async () => {
+    // tokenIn == USDB == fee asset -> input-side skim: quote the reduced input.
+    // (USDB, not WBTC, so quote() leaves the fee in base units rather than
+    // converting it to sats.) skim(10_030, 30) = 30 -> quoter sees 10_000.
+    configureReads({
+      grossOut: 2_000_000n,
+      hostBps: 30,
+      protocolBps: 0,
+      wbtc: WBTC,
+      usdb: USDB,
+    });
+    const res = await newAmm().quote({
+      assetInAddress: USDB,
       assetOutAddress: TOKEN_B,
+      amountIn: "10030",
+      fee: 3000,
+      slippageBps: 0,
+    });
+    expect(quoterAmountIn()).toBe(10_000n); // reduced input
+    expect(res.conductorFeeAsset).toBe(USDB);
+    expect(res.conductorFeeAmount).toBe("30"); // input-side fee
+    expect(res.amountOut).toBe("2000000"); // output not skimmed again
+  });
+
+  it("rejects a Conductor fee component above the protocol cap", async () => {
+    configureReads({ hostBps: 2000, protocolBps: 0 }); // > MAX_FEE_RATE_BPS
+    await expect(
+      newAmm().quote({
+        assetInAddress: TOKEN_A,
+        assetOutAddress: TOKEN_B,
+        amountIn: "1000",
+        fee: 3000,
+      })
+    ).rejects.toThrow(/exceeds the protocol maximum/);
+  });
+
+  it("converts a BTC input from sats to WBTC wei before quoting", async () => {
+    configureReads({ grossOut: 1_000_000n, hostBps: 0, protocolBps: 0 });
+    await newAmm().quote({
+      assetInAddress: "btc",
+      assetOutAddress: TOKEN_B,
+      amountIn: "250000", // sats
+      fee: 3000,
+    });
+    // tokenIn resolves to WBTC; with no fee the full wei amount is quoted.
+    expect(quoterAmountIn()).toBe(250_000n * WEI_PER_SAT);
+  });
+
+  it("converts a BTC output from WBTC wei back to whole sats", async () => {
+    configureReads({ grossOut: 100n * WEI_PER_SAT, hostBps: 0, protocolBps: 0 });
+    const res = await newAmm().quote({
+      assetInAddress: TOKEN_A,
+      assetOutAddress: "btc",
       amountIn: "1000000",
       fee: 3000,
     });
-    expect(q2.priceImpactBps).toBeUndefined();
+    expect(res.amountOut).toBe("100"); // 100 sats
+    expect(res.minAmountOut).toBe("99"); // weiToSats(99.5 sats) floors to 99
   });
 
-  it("throws when a BTC-out minAmountOut floors below 1 sat (no silent 0)", async () => {
-    // ~1.05 sat out; the slippage floor is just under 1 sat, so weiToSats
-    // would floor it to 0 — which would silently disable protection.
-    stubQuoteFetch({
-      ...GATEWAY_OK,
-      amountOut: (WEI_PER_SAT + 500_000_000n).toString(),
-      minAmountOut: (WEI_PER_SAT - 1n).toString(),
-    });
-    const amm = newAmm();
+  it("throws when a BTC-out minAmountOut floors below 1 sat", async () => {
+    // netOut just over 1 sat; the 50 bps haircut drops the floor below 1 sat
+    // (>0 wei) which would silently disable slippage protection.
+    configureReads({ grossOut: WEI_PER_SAT + 5n, hostBps: 0, protocolBps: 0 });
     await expect(
-      amm.quote({
+      newAmm().quote({
         assetInAddress: TOKEN_A,
         assetOutAddress: "btc",
         amountIn: "1000000",
         fee: 3000,
-        slippageBps: 50,
       })
-    ).rejects.toThrow(/disables slippage protection/);
+    ).rejects.toThrow(/below 1 sat/);
   });
 
-  it("reports a timeout when the gateway request aborts", async () => {
-    global.fetch = jest.fn(async () => {
-      const err = new Error("aborted");
-      err.name = "AbortError";
-      throw err;
-    }) as unknown as typeof fetch;
-    const amm = newAmm();
-    await expect(
-      amm.quote({
-        assetInAddress: TOKEN_A,
-        assetOutAddress: TOKEN_B,
-        amountIn: "1000000",
-        fee: 3000,
-      })
-    ).rejects.toThrow(/timed out after \d+ms/);
+  it("surfaces a best-effort price impact, and omits it when slot0 fails", async () => {
+    configureReads({
+      grossOut: 1_000_000n,
+      sqrtBefore: 1_000_000n,
+      sqrtAfter: 995_000n,
+    });
+    const withImpact = await newAmm().quote({
+      assetInAddress: TOKEN_A,
+      assetOutAddress: TOKEN_B,
+      amountIn: "1000",
+      fee: 3000,
+    });
+    expect(withImpact.priceImpactBps).toBe(100);
+
+    configureReads({ grossOut: 1_000_000n, slot0Throw: true });
+    const noImpact = await newAmm().quote({
+      assetInAddress: TOKEN_A,
+      assetOutAddress: TOKEN_B,
+      amountIn: "1000",
+      fee: 3000,
+    });
+    expect(noImpact.priceImpactBps).toBeUndefined();
   });
 });
 
-describe("TradingClient.quote — Conductor fee", () => {
-  it("forwards integratorBps to the gateway", async () => {
-    const calls = stubQuoteFetch(GATEWAY_OK);
-    const amm = newAmm();
-    await amm.quote({
-      assetInAddress: TOKEN_A,
-      assetOutAddress: TOKEN_B,
-      amountIn: "1000000",
-      fee: 3000,
-      integratorBps: 25,
-    });
-    expect(calls[0]?.body?.integratorBps).toBe(25);
-  });
+// ── quote() error mapping ────────────────────────────────────────────────────
 
-  it("omits integratorBps from the request when the caller omits it", async () => {
-    const calls = stubQuoteFetch(GATEWAY_OK);
-    const amm = newAmm();
-    await amm.quote({
-      assetInAddress: TOKEN_A,
-      assetOutAddress: TOKEN_B,
-      amountIn: "1000000",
-      fee: 3000,
-    });
-    expect(calls[0]?.body).not.toHaveProperty("integratorBps");
-  });
-
-  it("surfaces the Conductor fee fields for a token fee asset", async () => {
-    stubQuoteFetch({
-      ...GATEWAY_OK,
-      amountOut: "997010",
-      minAmountOut: "992025",
-      conductorFeeBps: 30,
-      conductorFeeAmount: "2988",
-      conductorFeeAsset: TOKEN_B,
-    });
-    const amm = newAmm();
-    const q = await amm.quote({
-      assetInAddress: TOKEN_A,
-      assetOutAddress: TOKEN_B,
-      amountIn: "1000000",
-      fee: 3000,
-      slippageBps: 50,
-    });
-    expect(q.conductorFeeBps).toBe(30);
-    expect(q.conductorFeeAmount).toBe("2988"); // token base units, unchanged
-    expect(q.conductorFeeAsset).toBe(TOKEN_B);
-  });
-
-  it("converts a WBTC Conductor fee to sats", async () => {
-    stubQuoteFetch({
-      ...GATEWAY_OK,
-      conductorFeeBps: 30,
-      conductorFeeAmount: (5n * WEI_PER_SAT).toString(),
-      conductorFeeAsset: WBTC,
-    });
-    const amm = newAmm();
-    const q = await amm.quote({
-      assetInAddress: "btc",
-      assetOutAddress: TOKEN_B,
-      amountIn: "1000000",
-      fee: 3000,
-    });
-    expect(q.conductorFeeAsset).toBe(WBTC);
-    expect(q.conductorFeeAmount).toBe("5"); // 5e10 wei -> 5 sats
-  });
-
-  it("reports zero fee when no Conductor fee applies", async () => {
-    stubQuoteFetch(GATEWAY_OK);
-    const amm = newAmm();
-    const q = await amm.quote({
-      assetInAddress: TOKEN_A,
-      assetOutAddress: TOKEN_B,
-      amountIn: "1000000",
-      fee: 3000,
-    });
-    expect(q.conductorFeeBps).toBe(0);
-    expect(q.conductorFeeAmount).toBe("0");
-    expect(q.conductorFeeAsset).toBeUndefined();
-  });
-
-  it("rejects out-of-range integratorBps", async () => {
-    stubQuoteFetch(GATEWAY_OK);
-    const amm = newAmm();
+describe("TradingClient.quote — errors", () => {
+  it("throws when the factory resolves no pool", async () => {
+    configureReads({ pool: zeroAddress });
     await expect(
-      amm.quote({
+      newAmm().quote({
         assetInAddress: TOKEN_A,
         assetOutAddress: TOKEN_B,
-        amountIn: "1000000",
+        amountIn: "1000",
         fee: 3000,
-        integratorBps: 1001,
       })
-    ).rejects.toThrow(/integratorBps/);
+    ).rejects.toThrow(/no pool/);
+  });
+
+  it("maps a QuoterV2 revert to no-pool / insufficient-liquidity", async () => {
+    configureReads({ quoterRevert: true });
+    await expect(
+      newAmm().quote({
+        assetInAddress: TOKEN_A,
+        assetOutAddress: TOKEN_B,
+        amountIn: "1000",
+        fee: 3000,
+      })
+    ).rejects.toThrow(/no pool or insufficient liquidity/);
+  });
+
+  it("rethrows a non-revert read failure (transport) unchanged", async () => {
+    configureReads({ grossOut: 1_000_000n });
+    mockReadContract.mockImplementation((call: { functionName: string }) => {
+      if (call.functionName === "quoteExactInputSingle") {
+        throw new BaseError("HTTP request failed");
+      }
+      if (call.functionName === "getPool") return POOL;
+      return 0;
+    });
+    await expect(
+      newAmm().quote({
+        assetInAddress: TOKEN_A,
+        assetOutAddress: TOKEN_B,
+        amountIn: "1000",
+        fee: 3000,
+      })
+    ).rejects.toThrow(/HTTP request failed/);
   });
 });


### PR DESCRIPTION
Replaces the removed gateway POST /api/v1/swap/quote with client-side QuoterV2 + Conductor-fee computation. Faithful port of the deleted quote.rs (vectors in quote-math.ts). type-check + 141 jest pass; no /api/v1/swap/quote refs remain.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace gateway HTTP quoting with client-side on-chain swap quoting in `TradingClient`
> - `TradingClient.quote()` is rewritten to call Uniswap V3 `QuoterV2.quoteExactInputSingle` directly via RPC instead of POSTing to the gateway `/api/v1/swap/quote` endpoint.
> - A new `computeSwapQuote()` private method folds Conductor host/protocol fees into the quote client-side, reading `hostFeeBps`, `protocolFeeBps`, `wbtc`, and `usdb` from the Conductor contract.
> - Pure bigint math helpers (`applySlippage`, `conductorSkim`, `priceImpactBps`, etc.) are extracted into a new [quote-math.ts](https://github.com/flashnetxyz/ts-sdk/pull/76/files#diff-6285e096f58f28d37e88f4b7ec1957d1ad1236940c19eb4ad12b693d87f462ee) module for unit-testable, RPC-free computation.
> - New ABIs for `QuoterV2` and Conductor fee getters are added in [uniswapV3.ts](https://github.com/flashnetxyz/ts-sdk/pull/76/files#diff-3b6c9937c4311cac7ced9290ba05096b0b292daa1f8562fa6dcf18e3fc63a063) and [conductor.ts](https://github.com/flashnetxyz/ts-sdk/pull/76/files#diff-83b9dc8d2882f73496e43c5a6f7021ae34712b5fc2d02219e527223c14de6d5b).
> - Behavioral Change: `TradingConfig` now requires `quoterV2Address` (and `factoryAddress` when `conductorAddress` is set); missing config causes `quote()` to throw. The `postSwapQuote` HTTP method and `QUOTE_TIMEOUT_MS` constant are removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f2970cf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->