### PR TITLE
close 2 test gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **BREAKING**: `TradingClient.quote()` now computes the swap quote client-side
+  over RPC — reading Uniswap V3 `QuoterV2.quoteExactInputSingle` and the
+  Conductor fee getters directly — instead of proxying the gateway's
+  `POST /api/v1/swap/quote`, which has been removed from the execution gateway
+  (DEX/product logic no longer lives there). `quote()` now requires
+  `quoterV2Address` **and** `factoryAddress` in `TradingConfig` and throws if
+  either is unset. Its public signature, `QuoteResult` shape, and BTC↔sats
+  handling are unchanged.
+
+### Migration Guide
+
+Pass the Uniswap V3 QuoterV2 and Factory addresses when constructing
+`TradingClient` (the same trading-stack addresses already used for swaps/LP):
+
+```typescript
+const trading = new TradingClient(exec, {
+  conductorAddress,
+  factoryAddress, // now required for quote()
+  quoterV2Address, // new — Uniswap V3 QuoterV2
+  // wbtcAddress, permit2Address, etc. as before
+});
+```
+
 ## [0.2.0] - 2024-01-XX
 
 ### Added

--- a/src/trading/quote.spec.ts
+++ b/src/trading/quote.spec.ts
@@ -352,6 +352,52 @@ describe("TradingClient.quote — computation", () => {
     expect(res.amountOut).toBe("2000000"); // output not skimmed again
   });
 
+  it("folds host + protocol + integrator fees into the total skim", async () => {
+    // total = 30 host + 20 protocol + 50 integrator = 100 bps (output-side,
+    // fee asset = tokenOut). skim(1_010_000, 100) = 10_000.
+    configureReads({
+      grossOut: 1_010_000n,
+      hostBps: 30,
+      protocolBps: 20,
+      wbtc: WBTC,
+      usdb: USDB,
+    });
+    const res = await newAmm().quote({
+      assetInAddress: TOKEN_A,
+      assetOutAddress: TOKEN_B,
+      amountIn: "1000000",
+      fee: 3000,
+      integratorBps: 50,
+      slippageBps: 0,
+    });
+    expect(res.conductorFeeBps).toBe(100); // all three components summed
+    expect(res.conductorFeeAmount).toBe("10000");
+    expect(res.amountOut).toBe("1000000"); // 1_010_000 - 10_000
+  });
+
+  it("reports a WBTC Conductor fee in whole sats, not wei", async () => {
+    // token -> BTC, fee asset = WBTC (the output leg). The 30 bps output skim is
+    // 30_000_000_000 wei; quote() must report it as 3 sats to match amountOut's
+    // units. skim(10_030_000_000_000, 30) = 30_000_000_000; net = 1_000 sats.
+    configureReads({
+      grossOut: 10_030_000_000_000n, // 1003 sats in WBTC wei
+      hostBps: 30,
+      protocolBps: 0,
+      wbtc: WBTC,
+      usdb: USDB,
+    });
+    const res = await newAmm().quote({
+      assetInAddress: TOKEN_A,
+      assetOutAddress: "btc",
+      amountIn: "1000000",
+      fee: 3000,
+      slippageBps: 0,
+    });
+    expect(res.conductorFeeAsset).toBe(WBTC);
+    expect(res.conductorFeeAmount).toBe("3"); // 30_000_000_000 wei -> 3 sats
+    expect(res.amountOut).toBe("1000"); // 10_000_000_000_000 wei -> 1000 sats
+  });
+
   it("rejects a Conductor fee component above the protocol cap", async () => {
     configureReads({ hostBps: 2000, protocolBps: 0 }); // > MAX_FEE_RATE_BPS
     await expect(

--- a/src/trading/quote.spec.ts
+++ b/src/trading/quote.spec.ts
@@ -372,6 +372,7 @@ describe("TradingClient.quote — computation", () => {
     });
     expect(res.conductorFeeBps).toBe(100); // all three components summed
     expect(res.conductorFeeAmount).toBe("10000");
+    expect(res.conductorFeeAsset).toBe(TOKEN_B); // neither leg is WBTC/USDB → tokenOut
     expect(res.amountOut).toBe("1000000"); // 1_010_000 - 10_000
   });
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add fee folding and WBTC sats conversion tests to `TradingClient.quote`
Adds two tests to [quote.spec.ts](https://github.com/flashnetxyz/ts-sdk/pull/77/files#diff-f360efd785df1aeaeb2092b06e4576b1347de759dfdfb8197d06913bb664eed3) covering previously untested computation paths:
- Verifies that host, protocol, and integrator fees are summed into `conductorFeeBps` and correctly skimmed from `amountOut`.
- Verifies that when the output asset is WBTC, `conductorFeeAmount` and `amountOut` are expressed in whole sats rather than wei.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized a4eaaaa.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->