### PR TITLE
fix(execution): omit deposit proof from signed intent

### DIFF
--- a/src/execution/client.ts
+++ b/src/execution/client.ts
@@ -225,9 +225,9 @@ export interface IntentExpiry {
 /**
  * "Bring your own proofs" opt-out. When `true`, `deposit` / `execute`
  * do not fetch any proofs themselves - the caller is responsible for
- * the entire proof flow, either by pre-attaching `depositProof` to
- * each entry of `deposits[]` (with a matching `nonce`) or by
- * deliberately submitting an unproven intent.
+ * the proof flow, either by pre-attaching `depositProof` to each
+ * entry of `deposits[]` or by deliberately submitting an unproven
+ * intent.
  *
  * Default is `false`: the SDK auto-fetches proofs for any deposit
  * that arrives without one. This is the recommended path - reach for
@@ -242,8 +242,8 @@ export interface ProofOptOut {
 export interface DepositParams extends IntentExpiry, ProofOptOut {
   /**
    * Spark transfers funding this deposit. Each entry that arrives
-   * without `depositProof` is automatically verified and proof-bound
-   * before the intent is signed - see `ProofOptOut` to disable.
+   * without `depositProof` is automatically verified before submit -
+   * see `ProofOptOut` to disable.
    */
   deposits: Deposit[];
   /** EVM address to credit. If omitted, credits the identity key's EVM address. */
@@ -256,11 +256,8 @@ export interface DepositParams extends IntentExpiry, ProofOptOut {
  * This is the modular escape hatch - most callers should let
  * `deposit` / `execute` handle proof fetching automatically.
  *
- * `intentId` is the canonical BLAKE3 hash of the intent the caller is
- * about to submit. Compute it via {@link canonicalIntentId} from the
- * exact canonical transfers + action you intend to sign — the gateway
- * binds the returned proofs to this value and a mismatch on `/execute`
- * is a hard rejection.
+ * `intentId` is retained by the gateway for compatibility with existing
+ * callers. Transfer attestations are intent-agnostic and do not bind to it.
  */
 export interface VerifyDepositParams {
   intentId: string;
@@ -307,8 +304,8 @@ export interface WaitForIntentOptions {
 export interface ExecuteParams extends IntentExpiry, ProofOptOut {
   /**
    * Spark transfers to credit before executing. Each entry without an
-   * attached `depositProof` is auto-verified before the intent is
-   * signed - see `ProofOptOut` to disable.
+   * attached `depositProof` is auto-verified before submit - see
+   * `ProofOptOut` to disable.
    */
   deposits?: Deposit[];
   /** Hex-encoded signed EVM transaction (RLP-serialized, 0x-prefixed). */
@@ -467,19 +464,16 @@ export class ExecutionClient {
    *
    * Credits the deposited funds to the specified recipient or the
    * identity key's EVM address. Any deposit that arrives without an
-   * attached `depositProof` is automatically proof-bound first by an
+   * attached `depositProof` is automatically fetched first by an
    * internal `/verifyDeposit` call; the resulting proofs are stitched
    * into the request the gateway receives. Pass `params.manualProofs:
    * true` to take over the proof flow (e.g., to inspect rejections,
    * cache proofs, or submit unproven), or pre-populate
-   * `deposits[i].depositProof` if proofs were fetched out of band
-   * against the same canonical intent.
+   * `deposits[i].depositProof` if proofs were fetched out of band.
    *
-   * If the gateway has not enabled proof verification yet (returns
-   * 503) the call falls back to the legacy proofless path. Any
-   * per-transfer rejection from the verification step is surfaced as
-   * an error before the intent is signed - the SDK never silently
-   * drops or downgrades a deposit.
+   * If the preflight attester is unavailable (503), `/execute` still
+   * performs its normal server-side attestation attempt. Any
+   * per-transfer rejection from preflight is surfaced before submit.
    */
   async deposit(params: DepositParams): Promise<ExecuteResponse> {
     this.requireAuth();
@@ -540,17 +534,12 @@ export class ExecutionClient {
    * Auto-attach proofs for any deposit that arrives without one.
    *
    * Returns the (possibly mutated) deposit list. Pre-attached proofs
-   * are kept as-is; the caller is responsible for ensuring they were
-   * minted against the same canonical intent (same `intentId`). The
-   * gateway will reject mismatched bindings on `/execute`.
+   * are kept as-is.
    *
-   * On 503 from the gateway (proof verification not yet enabled), each
-   * deposit without a pre-attached proof receives the placeholder
-   * shape so the canonical preimage still includes a `depositProof`
-   * field. The gateway's `has_valid_shape()` check treats placeholders
-   * as "not configured" and falls through to the legacy polling
-   * admission. Any other failure - including a non-empty `rejections[]`
-   * - throws to surface the issue before the intent is signed.
+   * On 503 from the gateway (attester unavailable), deposits without a
+   * pre-attached proof flow through unchanged. Any other failure -
+   * including a non-empty `rejections[]` - throws to surface the issue
+   * before the intent is submitted.
    */
   private async resolveProofs(
     deposits: Deposit[],
@@ -560,15 +549,23 @@ export class ExecutionClient {
     // Validate the shape of any pre-attached proof so a malformed
     // `depositProof` (wrong-length signature, etc.) fails here with a
     // clear message rather than being rejected by the gateway after
-    // the intent is signed. The gateway accepts both `0x`-prefixed
+    // submit. The gateway accepts both `0x`-prefixed
     // and bare hex - so does this check.
     for (let i = 0; i < deposits.length; i++) {
       const proof = deposits[i]!.depositProof;
       if (proof) {
-        if (typeof proof.payloadBytes !== "string" || proof.payloadBytes.trim() === "") {
-          throw new Error(`deposits[${i}].depositProof.payloadBytes is missing or empty`);
+        if (
+          typeof proof.payloadBytes !== "string" ||
+          proof.payloadBytes.trim() === ""
+        ) {
+          throw new Error(
+            `deposits[${i}].depositProof.payloadBytes is missing or empty`
+          );
         }
-        if (typeof proof.signature !== "string" || !SIGNATURE_HEX_RE.test(proof.signature)) {
+        if (
+          typeof proof.signature !== "string" ||
+          !SIGNATURE_HEX_RE.test(proof.signature)
+        ) {
           throw new Error(
             `deposits[${i}].depositProof.signature must be 64 hex bytes (128 chars, optional 0x prefix)`
           );
@@ -598,11 +595,8 @@ export class ExecutionClient {
         sparkTransferIds: missing.map((i) => deposits[i]!.sparkTransferId),
       });
     } catch (err) {
-      // Soft-mode fallback: if the gateway does not yet expose
-      // /verifyDeposit it returns 503. Fall through to the legacy
-      // proofless path instead of failing the caller's intent. Any
-      // pre-attached proofs flow through unchanged - the legacy path
-      // ignores the placeholder shape via `has_valid_shape()`.
+      // If the attester is unavailable, let /execute perform its normal
+      // server-side attestation attempt and return the authoritative error.
       if (isGatewayUnavailable(err)) {
         return deposits;
       }
@@ -1028,27 +1022,28 @@ export class ExecutionClient {
   ): Promise<ExecuteResponse> {
     const expiresAt = resolveExpiresAt(requestAction.expiresAt);
 
-    // Build wire-shaped transfers (no proofs yet). The intent_id BLAKE3
-    // preimage does NOT cover `depositProof` or `expiresAt`, so we can
-    // compute the canonical intent id from a proof-less projection and
-    // attach proofs afterwards. See `canonicalIntentId` in ./types.
-    const placeholderTransfers: CanonicalTransferEntry[] = rawDeposits.map((d) => {
-      const amountBig =
-        typeof d.amount === "bigint" ? d.amount : BigInt(d.amount);
-      if (amountBig < 0n) {
-        throw new Error(`deposits[${d.sparkTransferId}].amount must be non-negative`);
+    // Build proofless transfers for the intent id. The BLAKE3 preimage
+    // does not cover `depositProof` or `expiresAt`.
+    const intentIdTransfers: CanonicalTransferEntry[] = rawDeposits.map(
+      (d) => {
+        const amountBig =
+          typeof d.amount === "bigint" ? d.amount : BigInt(d.amount);
+        if (amountBig < 0n) {
+          throw new Error(
+            `deposits[${d.sparkTransferId}].amount must be non-negative`
+          );
+        }
+        return {
+          transferId: d.sparkTransferId,
+          amount: u256Hex(amountBig),
+          asset: depositAssetToWire(d.asset),
+        };
       }
-      return {
-        transferId: d.sparkTransferId,
-        amount: u256Hex(amountBig),
-        asset: depositAssetToWire(d.asset),
-        depositProof: d.depositProof ?? PLACEHOLDER_DEPOSIT_PROOF,
-      };
-    });
+    );
 
     const intentId = canonicalIntentId({
       chainId: this.config.chainId,
-      transfers: placeholderTransfers,
+      transfers: intentIdTransfers,
       action,
       recipientForHash: requestAction.recipientForHash,
       signedTxHex: requestAction.evmTransaction,
@@ -1056,17 +1051,15 @@ export class ExecutionClient {
 
     // Auto-attach proofs for any deposit that arrives without one. The
     // returned `Deposit[]` is the same caller-facing shape with
-    // `depositProof` populated. Falls through silently on a 503 from
-    // /verifyDeposit (soft-mode gateway), and throws on any
-    // per-transfer rejection.
+    // `depositProof` populated when /verifyDeposit succeeds.
     const deposits = await this.resolveProofs(
       rawDeposits,
       intentId,
       requestAction.manualProofs
     );
 
-    // Final canonical transfers with resolved proofs (or placeholders).
-    const transfers: CanonicalTransferEntry[] = deposits.map((d) => {
+    // Final request-body transfers with resolved proofs (or placeholders).
+    const transfers = deposits.map((d) => {
       const amountBig =
         typeof d.amount === "bigint" ? d.amount : BigInt(d.amount);
       return {
@@ -1106,7 +1099,7 @@ export class ExecutionClient {
         : action;
     const canonicalMessage: CanonicalIntentMessageWire = {
       chainId: this.config.chainId,
-      transfers,
+      transfers: intentIdTransfers,
       action: messageAction,
       expiresAt,
     };
@@ -1117,11 +1110,6 @@ export class ExecutionClient {
     // Body mirrors the Rust `ExecuteRequest` struct. `amount` is U256
     // hex on the Rust side; we emit `0x`-prefixed lowercase hex
     // matching alloy's serde shape.
-    //
-    // Each deposit carries a `depositProof` (either the gateway-signed
-    // value from /verifyDeposit, a caller-supplied pre-attached proof,
-    // or the {payloadBytes:"0x", signature:"0x"} placeholder that the
-    // gateway treats as "not configured" via has_valid_shape()).
     const body: Record<string, unknown> = {
       chainId: this.config.chainId,
       deposits: transfers.map((t) => ({

--- a/src/execution/deposit-proof.spec.ts
+++ b/src/execution/deposit-proof.spec.ts
@@ -2,6 +2,7 @@
  * Tests for the deposit-proof types, helpers, and auto-attach flow.
  */
 import { ExecutionClient, VerifyDepositRejectedError } from "./client";
+import { stringifyWithBigint } from "./client";
 import {
   PLACEHOLDER_DEPOSIT_PROOF,
   canonicalIntentId,
@@ -15,17 +16,21 @@ import {
 } from "./types";
 import type { SparkWalletInput } from "./spark-evm-account";
 import { secp256k1 } from "@noble/curves/secp256k1";
+import { sha256 } from "@noble/hashes/sha2";
 
 const TEST_KEY = new Uint8Array(32);
 TEST_KEY[31] = 1;
 
-function mockWallet(): SparkWalletInput {
+function mockWallet(onSign?: (hash: Uint8Array) => void): SparkWalletInput {
   return {
     config: {
       signer: {
         getIdentityPublicKey: async () =>
           secp256k1.getPublicKey(TEST_KEY, true),
-        signMessageWithIdentityKey: async () => new Uint8Array(64),
+        signMessageWithIdentityKey: async (hash: Uint8Array) => {
+          onSign?.(hash);
+          return new Uint8Array(64);
+        },
       },
     },
   } as unknown as SparkWalletInput;
@@ -109,9 +114,8 @@ describe("canonicalIntentId", () => {
       transferId: "a1b2c3d4e5f60718a1b2c3d4e5f60718",
       amount: "0x186a0",
       asset: { type: "NATIVE_SATS" },
-      depositProof: PLACEHOLDER_DEPOSIT_PROOF,
     };
-    const withProof: CanonicalTransferEntry = {
+    const withProof = {
       ...baseTransfer,
       depositProof: SAMPLE_PROOF,
     };
@@ -139,7 +143,6 @@ describe("canonicalIntentId", () => {
       transferId,
       amount: "0x186a0",
       asset: { type: "NATIVE_SATS" },
-      depositProof: PLACEHOLDER_DEPOSIT_PROOF,
     });
     const dashed = canonicalIntentId({
       chainId: 21022,
@@ -189,9 +192,12 @@ describe("VerifyDeposit type round-trips", () => {
 });
 
 describe("ExecutionClient.deposit auto-attach flow", () => {
-  function authenticatedClient(fetchMock: jest.Mock): ExecutionClient {
+  function authenticatedClient(
+    fetchMock: jest.Mock,
+    onSign?: (hash: Uint8Array) => void
+  ): ExecutionClient {
     global.fetch = fetchMock as unknown as typeof fetch;
-    const client = new ExecutionClient(mockWallet(), EXEC_CONFIG);
+    const client = new ExecutionClient(mockWallet(onSign), EXEC_CONFIG);
     // Bypass the real auth handshake.
     (client as unknown as { accessToken: string }).accessToken = "test-token";
     return client;
@@ -202,6 +208,8 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
       proofs: [{ index: 0, proof: SAMPLE_PROOF }],
       rejections: [],
     };
+    const expiresAt = 1_893_456_000_000;
+    const signedHashes: Uint8Array[] = [];
     const executeResp = {
       submissionId: "sub-1",
       intentId: "0xabc",
@@ -215,7 +223,9 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
       throw new Error(`unexpected URL: ${url}`);
     });
 
-    const client = authenticatedClient(fetchMock);
+    const client = authenticatedClient(fetchMock, (hash) =>
+      signedHashes.push(new Uint8Array(hash))
+    );
     const result = await client.deposit({
       deposits: [
         {
@@ -225,6 +235,7 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
         },
       ],
       recipient: RECIPIENT,
+      expiresAt,
     });
 
     expect(result.submissionId).toBe("sub-1");
@@ -246,6 +257,36 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
     // No top-level `nonce` field — replay defense is structural via intent_id.
     expect(body.nonce).toBeUndefined();
 
+    const expectedSignedMessage = {
+      chainId: EXEC_CONFIG.chainId,
+      transfers: [
+        {
+          transferId: "a1b2c3d4e5f60718a1b2c3d4e5f60718",
+          amount: "0x186a0",
+          asset: { type: "NATIVE_SATS" },
+        },
+      ],
+      action: { type: "deposit", recipient: RECIPIENT.toLowerCase() },
+      expiresAt,
+    };
+    const expectedSignedHash = sha256(
+      new TextEncoder().encode(stringifyWithBigint(expectedSignedMessage))
+    );
+    const prooffulMessage = {
+      ...expectedSignedMessage,
+      transfers: [
+        { ...expectedSignedMessage.transfers[0], depositProof: SAMPLE_PROOF },
+      ],
+    };
+    const prooffulHash = sha256(
+      new TextEncoder().encode(stringifyWithBigint(prooffulMessage))
+    );
+    expect(signedHashes).toHaveLength(1);
+    expect(Array.from(signedHashes[0]!)).toEqual(
+      Array.from(expectedSignedHash)
+    );
+    expect(Array.from(signedHashes[0]!)).not.toEqual(Array.from(prooffulHash));
+
     // /verifyDeposit body carries the canonical intentId, not a random nonce.
     const verifyCall = fetchMock.mock.calls.find((c) =>
       String(c[0]).endsWith("/api/v1/verifyDeposit")
@@ -264,7 +305,6 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
           transferId: "a1b2c3d4e5f60718a1b2c3d4e5f60718",
           amount: "0x186a0",
           asset: { type: "NATIVE_SATS" },
-          depositProof: PLACEHOLDER_DEPOSIT_PROOF,
         },
       ],
       action: { type: "deposit", recipient: RECIPIENT.toLowerCase() },
@@ -333,9 +373,8 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
     );
     if (!executeCall) throw new Error("/execute was not called");
     const body = JSON.parse(String((executeCall[1] as RequestInit).body));
-    // On 503 the placeholder shape is sent — the gateway's
-    // has_valid_shape() treats it as "not configured" and falls through
-    // to the legacy admission path.
+    // On 503 the placeholder shape is sent. The gateway ignores
+    // client-supplied proof authority and performs server-side attestation.
     expect(body.deposits[0].depositProof).toEqual(PLACEHOLDER_DEPOSIT_PROOF);
   });
 
@@ -379,9 +418,7 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
 
     // /execute was never reached.
     expect(
-      fetchMock.mock.calls.some((c) =>
-        String(c[0]).endsWith("/api/v1/execute")
-      )
+      fetchMock.mock.calls.some((c) => String(c[0]).endsWith("/api/v1/execute"))
     ).toBe(false);
   });
 
@@ -448,10 +485,9 @@ describe("ExecutionClient.deposit auto-attach flow", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(String(fetchMock.mock.calls[0]![0])).toContain("/api/v1/execute");
-    // manualProofs skips /verifyDeposit, but the wire requires a
+    // manualProofs skips /verifyDeposit, but the wire still accepts a
     // `depositProof` field on every Deposit. The SDK fills missing
-    // proofs with the placeholder shape — has_valid_shape() returns
-    // false, so the gateway falls through to legacy admission.
+    // proofs with the placeholder shape.
     const body = JSON.parse(
       String((fetchMock.mock.calls[0]![1] as RequestInit).body)
     );

--- a/src/execution/stringify-bigint.spec.ts
+++ b/src/execution/stringify-bigint.spec.ts
@@ -98,10 +98,10 @@ describe("stringifyWithBigint", () => {
   // canonical intent message. The validator hashes the JSON output
   // byte-for-byte and the signed bytes must match the Rust
   // CanonicalIntentMessage struct (chainId, transfers, action,
-  // expiresAt — no `nonce` since migration 0008), with each
-  // CanonicalTransferEntry in the order
-  // (transferId, amount, asset, depositProof). If someone reorders the
-  // TS interface, the Rust struct, or the object literal in
+  // expiresAt — no `nonce` since migration 0008), with each transfer
+  // in the order (transferId, amount, asset). `depositProof` is not
+  // part of this signed JSON. If someone reorders the TS interface,
+  // the Rust struct, or the object literal in
   // ExecutionClient.submitIntent, this test will fail loudly instead of
   // breaking signature verification at runtime.
   it("canonical intent message matches the Rust struct field order", () => {
@@ -110,7 +110,6 @@ describe("stringifyWithBigint", () => {
         transferId: "transfer-1",
         amount: "0x3e8",
         asset: { type: "NATIVE_SATS" },
-        depositProof: { payloadBytes: "0x", signature: "0x" },
       },
       {
         transferId: "transfer-2",
@@ -119,10 +118,6 @@ describe("stringifyWithBigint", () => {
           type: "SPARK_TOKEN",
           tokenId:
             "0x0000000000000000000000000000000000000000000000000000000000000001",
-        },
-        depositProof: {
-          payloadBytes: "0xdeadbeef",
-          signature: "0x" + "ab".repeat(64),
         },
       },
     ];
@@ -135,10 +130,8 @@ describe("stringifyWithBigint", () => {
     expect(stringifyWithBigint(message)).toEqual(
       '{"chainId":21022,' +
         '"transfers":[' +
-        '{"transferId":"transfer-1","amount":"0x3e8","asset":{"type":"NATIVE_SATS"},"depositProof":{"payloadBytes":"0x","signature":"0x"}},' +
-        '{"transferId":"transfer-2","amount":"0x9c4","asset":{"type":"SPARK_TOKEN","tokenId":"0x0000000000000000000000000000000000000000000000000000000000000001"},"depositProof":{"payloadBytes":"0xdeadbeef","signature":"0x' +
-        "ab".repeat(64) +
-        '"}}' +
+        '{"transferId":"transfer-1","amount":"0x3e8","asset":{"type":"NATIVE_SATS"}},' +
+        '{"transferId":"transfer-2","amount":"0x9c4","asset":{"type":"SPARK_TOKEN","tokenId":"0x0000000000000000000000000000000000000000000000000000000000000001"}}' +
         "]," +
         '"action":{"type":"deposit","recipient":"0xabc"},' +
         '"expiresAt":1893456000000}'

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -23,11 +23,8 @@ export interface Deposit {
   /**
    * Optional signed deposit proof obtained from `POST /api/v1/verifyDeposit`.
    *
-   * When present, the gateway re-verifies the proof on `/execute` before
-   * forwarding the intent. When absent, the SDK either fetches one
-   * automatically (the default) or sends a placeholder shape that the
-   * gateway treats as "not configured" and falls through to the legacy
-   * admission path.
+   * The gateway treats this as transport evidence only. It is not part
+   * of the user-signed canonical intent message.
    */
   depositProof?: SignedDepositProof;
 }
@@ -50,11 +47,8 @@ export interface SignedDepositProof {
 /**
  * Request body for `POST /api/v1/verifyDeposit`.
  *
- * `intentId` is the canonical 32-byte BLAKE3 hash of the intent the SDK
- * is about to submit on `/execute`. The returned proofs bind to this
- * value, so a proof minted for intent A cannot be re-attached to a
- * request whose body hashes to intent B. Compute it via
- * {@link canonicalIntentId} from the message you intend to sign.
+ * `intentId` is retained for compatibility with existing callers. Transfer
+ * attestations are intent-agnostic and do not bind to this value.
  *
  * Each transfer's `sparkTransferId` may be supplied as a dashed UUID, a
  * raw hex string (with or without `0x`), or a 64-char hex string for
@@ -358,12 +352,11 @@ export type Asset =
   | { type: "SPARK_TOKEN"; tokenId: string };
 
 /**
- * Canonical transfer entry in the signed intent message.
+ * Transfer entry in the user-signed canonical intent message.
  *
- * Mirrors Rust `CanonicalTransferEntry` (camelCase, serde declaration
- * order: `transferId`, `amount`, `asset`, `depositProof`). The deposit
- * proof is part of the signed preimage — omitting it on the SDK side
- * breaks signature verification.
+ * Mirrors Rust `CanonicalTransferEntry` serialization order:
+ * `transferId`, `amount`, `asset`. `depositProof` is deliberately omitted
+ * from the signature preimage and is only carried on the `/execute` request body.
  *
  * `amount` is the alloy `U256` JSON shape: `0x`-prefixed lowercase hex
  * with no leading zeros (`"0x0"` for zero).
@@ -372,7 +365,6 @@ export interface CanonicalTransferEntry {
   transferId: string;
   amount: string;
   asset: Asset;
-  depositProof: SignedDepositProof;
 }
 
 /**
@@ -483,12 +475,8 @@ export function depositAssetToWire(asset: DepositAsset): Asset {
 }
 
 /**
- * Placeholder {@link SignedDepositProof} used on the legacy/soft-mode
- * admission path. The gateway treats any proof that fails
- * `has_valid_shape()` (empty payload OR non-64-byte signature) as
- * "not configured" and falls through to the polling admission. The
- * SDK uses this when `/verifyDeposit` returns 503 or when
- * `manualProofs: true` is set without an attached proof.
+ * Placeholder {@link SignedDepositProof} used when the request body needs a
+ * proof-shaped value but the caller has not supplied one.
  */
 export const PLACEHOLDER_DEPOSIT_PROOF: SignedDepositProof = {
   payloadBytes: "0x",
@@ -584,7 +572,8 @@ export function clawbackSparkTxidWire(sparkTxid: string): ClawbackSparkTxidWire 
  *     Clawback  → 0x02 + sparkTxid.canonical_bytes (tag + bytes)
  *
  * Note: `expiresAt` and per-transfer `depositProof` are NOT part of the
- * BLAKE3 preimage — they live only on the JSON signed-preimage.
+ * BLAKE3 preimage. `expiresAt` is part of the JSON signed preimage;
+ * `depositProof` is not.
  *
  * `recipientForHash` must be the canonical 20-byte recipient determined
  * by the action variant — the caller is responsible for recovering the


### PR DESCRIPTION
## Summary
- make CanonicalTransferEntry represent the proofless signed intent transfer shape
- keep depositProof only as /execute transport evidence
- update SDK signing/golden-vector tests so the signed CanonicalIntentMessage excludes depositProof

## Tests
- npm run type-check
- npx jest src/execution/deposit-proof.spec.ts src/execution/stringify-bigint.spec.ts --runInBand
- npm run build

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Omit `depositProof` from the signed canonical intent message in `ExecutionClient`
> - The `CanonicalTransferEntry` type and signing workflow in [`client.ts`](https://github.com/flashnetxyz/ts-sdk/pull/81/files#diff-aa839a246a243d62eae2a42349f66de061dd3599fa0c873c35be53877bd6ec64) now exclude `depositProof`; only `transferId`, `amount`, and `asset` are included in the signed JSON preimage.
> - The `/execute` request body still carries `depositProof` per deposit (or a placeholder), preserving server-side attestation.
> - On a 503 from `/verifyDeposit`, deposits without a pre-attached proof are now returned unchanged instead of injecting placeholder proofs at that stage.
> - Behavioral Change: The bytes signed by the wallet change — any existing signature verification that expected `depositProof` in the signed payload will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f31477.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->