### PR TITLE
fix(execution): authenticate getIntentStatus against the gateway

### DIFF
--- a/src/execution/client.ts
+++ b/src/execution/client.ts
@@ -846,20 +846,24 @@ export class ExecutionClient {
   /**
    * Look up the lifecycle status of a previously submitted intent.
    *
-   * Calls `GET /api/v1/intents/{submissionId}` on the gateway. No auth
-   * required — submission IDs are non-guessable handles, and a leak only
-   * exposes status text. Use {@link waitForIntent} to poll until a target
-   * status is reached.
+   * Calls `GET /api/v1/intents/{submissionId}` on the gateway. Requires
+   * authentication: the gateway authorizes the submission against the
+   * caller's access token and returns 404 for a submission the caller does
+   * not own. Use {@link waitForIntent} to poll until a target status is
+   * reached.
    *
-   * @throws if the submission is unknown (HTTP 404) or the gateway is
-   *   unreachable.
+   * @throws if the client is not authenticated, if the submission is unknown
+   *   or not owned by the caller (HTTP 404), or if the gateway is unreachable.
    */
   async getIntentStatus(submissionId: string): Promise<IntentStatusResponse> {
     if (!submissionId || submissionId.trim() === "") {
       throw new Error("submissionId is required");
     }
+    this.requireAuth();
     const path = `/api/v1/intents/${encodeURIComponent(submissionId)}`;
-    const resp = await fetch(`${this.config.gatewayUrl}${path}`);
+    const resp = await fetch(`${this.config.gatewayUrl}${path}`, {
+      headers: { Authorization: `Bearer ${this.accessToken}` },
+    });
     const text = await resp.text();
     if (!resp.ok) {
       throw new Error(

--- a/src/execution/intent-status-auth.spec.ts
+++ b/src/execution/intent-status-auth.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * getIntentStatus must authenticate. The execution-layer gateway authorizes the
+ * submission against the caller's access token (IDOR fix), so an unauthenticated
+ * poll of GET /api/v1/intents/{id} now returns 404. The SDK must attach the
+ * Bearer token it obtained from the gateway verify step.
+ */
+
+import { secp256k1 } from "@noble/curves/secp256k1";
+import { ExecutionClient } from "./client";
+import type { SparkWalletInput } from "./spark-evm-account";
+
+const TEST_KEY = new Uint8Array(32);
+TEST_KEY[31] = 1;
+
+function mockWallet(): SparkWalletInput {
+  return {
+    config: {
+      signer: {
+        getIdentityPublicKey: async () =>
+          secp256k1.getPublicKey(TEST_KEY, true),
+        signMessageWithIdentityKey: async () => new Uint8Array(64),
+      },
+    },
+  } as unknown as SparkWalletInput;
+}
+
+const EXEC_CONFIG = {
+  gatewayUrl: "http://localhost:8080",
+  rpcUrl: "http://localhost:8545",
+  chainId: 21022,
+};
+
+function okResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("ExecutionClient.getIntentStatus auth", () => {
+  it("sends the access token as a Bearer header", async () => {
+    const fetchMock = jest.fn(async () =>
+      okResponse({ submissionId: "sub-1", status: "finalized" })
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const client = new ExecutionClient(mockWallet(), EXEC_CONFIG);
+    (client as unknown as { accessToken: string }).accessToken = "test-token";
+
+    await client.getIntentStatus("sub-1");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(String(url)).toContain("/api/v1/intents/sub-1");
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer test-token"
+    );
+  });
+
+  it("throws and does not call the gateway when unauthenticated", async () => {
+    const fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const client = new ExecutionClient(mockWallet(), EXEC_CONFIG);
+
+    await expect(client.getIntentStatus("sub-1")).rejects.toThrow();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Why

The execution-layer gateway (`flashnet-execution`) now authorizes `GET /api/v1/intents/{submissionId}` against the caller's access token — an IDOR fix that returns **404** for a submission the caller does not own. `ExecutionClient.getIntentStatus` was unauthenticated (its doc literally said "No auth required"), so against the updated gateway it 404s and `waitForIntent` loops until timeout. This is what's failing the `sdk-e2e` suite on the execution-layer hardening PR.

## What

- `getIntentStatus` now calls `requireAuth()` and sends `Authorization: Bearer <accessToken>` — the token the client already obtains from the gateway verify step. The gateway's ownership check passes because the token subject is the same pubkey that signed the intent.
- Updated the doc comment (it claimed no auth was needed).
- Added `intent-status-auth.spec.ts`: asserts the Bearer header is sent, and that an unauthenticated call throws without hitting the gateway.

## Verify

`tsc --noEmit` clean; `jest intent-status-auth.spec.ts` → 2/2 pass; biome adds no new findings (the spec's `jest`-undeclared notes match every existing spec — biome.json only declares `Bun`).

Targets `feat/execution-client-spark-wallet` since the execution client lives there. Pairs with the gateway IDOR fix in flashnet-execution PR #944.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate `ExecutionClient.getIntentStatus` requests with a Bearer token
> - `getIntentStatus` now calls `requireAuth()` before making any network request and includes an `Authorization: Bearer` header in the request to the gateway.
> - Adds Jest tests in [intent-status-auth.spec.ts](https://github.com/flashnetxyz/ts-sdk/pull/82/files#diff-25f8bd5cefa962f67f28bd5553aae17df4a4763c11eaa2b0c4fb5c9237bd1312) covering both the authenticated header and the unauthenticated early-throw behavior.
> - Behavioral Change: unauthenticated clients will now throw before any fetch is issued, rather than making an unauthenticated request.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 575a944.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->