### PR TITLE
feat(execution): align execution client with hardened gateway RPC contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,11 @@
 - `execution` now exports the gateway RPC contract the execution client honors:
   `MAX_JSON_RPC_BATCH_REQUESTS` (100), `GATEWAY_BLOCKED_STATEFUL_FILTER_METHODS`
   (the six `eth_*Filter` methods), `isGatewayBlockedStatefulFilter`, and
-  `assertJsonRpcBatchWithinLimit`. These mirror the gateway's hardened public
-  RPC surface so the execution client stays aligned. The client is already
+  `assertJsonRpcBatchWithinLimit`. These mirror the gateway's public RPC
+  surface so the execution client stays aligned. The client is already
   compatible (Multicall3 + `eth_getLogs`, a non-batching viem `http()`
   transport, and it always sends the configured `chainId` and a valid auth
   public key); this is a guardrail to keep future changes within the contract.
-  Companion to flashnet-execution PRs #1025, #1028, #1090, #1169, #1170.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Added
+
+- `execution` now exports the gateway RPC contract the execution client honors:
+  `MAX_JSON_RPC_BATCH_REQUESTS` (100), `GATEWAY_BLOCKED_STATEFUL_FILTER_METHODS`
+  (the six `eth_*Filter` methods), `isGatewayBlockedStatefulFilter`, and
+  `assertJsonRpcBatchWithinLimit`. These mirror the gateway's hardened public
+  RPC surface so the execution client stays aligned. The client is already
+  compatible (Multicall3 + `eth_getLogs`, a non-batching viem `http()`
+  transport, and it always sends the configured `chainId` and a valid auth
+  public key); this is a guardrail to keep future changes within the contract.
+  Companion to flashnet-execution PRs #1025, #1028, #1090, #1169, #1170.
+
 ### Changed
 
 - **BREAKING**: `TradingClient.quote()` now computes the swap quote client-side

--- a/src/execution/gateway-rpc-policy.spec.ts
+++ b/src/execution/gateway-rpc-policy.spec.ts
@@ -1,0 +1,37 @@
+import {
+  assertJsonRpcBatchWithinLimit,
+  GATEWAY_BLOCKED_STATEFUL_FILTER_METHODS,
+  isGatewayBlockedStatefulFilter,
+  MAX_JSON_RPC_BATCH_REQUESTS,
+} from "./gateway-rpc-policy";
+
+describe("gateway-rpc-policy", () => {
+  it("blocks exactly the six stateful filter methods", () => {
+    expect(GATEWAY_BLOCKED_STATEFUL_FILTER_METHODS).toHaveLength(6);
+    for (const method of GATEWAY_BLOCKED_STATEFUL_FILTER_METHODS) {
+      expect(isGatewayBlockedStatefulFilter(method)).toBe(true);
+    }
+  });
+
+  it("does not block read-only methods the client uses", () => {
+    for (const method of [
+      "eth_getLogs",
+      "eth_call",
+      "eth_blockNumber",
+      "eth_getTransactionReceipt",
+      "eth_chainId",
+    ]) {
+      expect(isGatewayBlockedStatefulFilter(method)).toBe(false);
+    }
+  });
+
+  it("enforces the batch limit at the boundary", () => {
+    expect(MAX_JSON_RPC_BATCH_REQUESTS).toBe(100);
+    expect(() =>
+      assertJsonRpcBatchWithinLimit(MAX_JSON_RPC_BATCH_REQUESTS)
+    ).not.toThrow();
+    expect(() =>
+      assertJsonRpcBatchWithinLimit(MAX_JSON_RPC_BATCH_REQUESTS + 1)
+    ).toThrow(/exceeds the gateway limit/);
+  });
+});

--- a/src/execution/gateway-rpc-policy.ts
+++ b/src/execution/gateway-rpc-policy.ts
@@ -1,38 +1,26 @@
 /**
- * Gateway RPC contract the execution client must honor.
+ * Gateway RPC contract the execution client honors.
  *
- * The Flashnet execution gateway hardened its public RPC and admission surface
- * (see the linked flashnet-execution PRs). This module captures the resulting
- * contract as the SDK's single source of truth so the execution client — and
- * future work on it — stays aligned with what the gateway will actually accept:
+ * The gateway constrains the public JSON-RPC surface it accepts. This module
+ * captures that contract as the SDK's single source of truth so the execution
+ * client — and future work on it — stays within what the gateway accepts:
  *
- * - Stateful filter methods are rejected on every public RPC lane because they
- *   allocate server-side reth filter state on a shared endpoint. Read logs with
+ * - Stateful filter methods are not accepted on the public RPC surface: they
+ *   allocate server-side filter state on a shared endpoint. Read logs with
  *   `eth_getLogs` range queries instead of server-side filters.
- *   (flashnet-execution #1028; also #1025 for the `/access/{apikey}` lane)
  * - A single JSON-RPC batch may carry at most `MAX_JSON_RPC_BATCH_REQUESTS`
  *   requests. The execution client uses Multicall3 to aggregate reads into one
  *   `eth_call` and a non-batching viem `http()` transport, so it does not emit
  *   JSON-RPC arrays today; cap any future batching at this limit.
- *   (flashnet-execution #1170)
- * - `/access/{apikey}` is read-only: a key's `allowed_methods` are intersected
- *   with the gateway's read-only whitelist, so write/admin methods are denied
- *   regardless of the key. (flashnet-execution #1025)
- * - `POST /v1/execute` rejects intents whose `chainId` does not match the
- *   execution chain with HTTP 400 before any signature/proof work. The client
- *   always sends `config.chainId`. (flashnet-execution #1090)
- * - `/v1/auth/challenge` and `/v1/auth/verify` reject a malformed `public_key`
- *   with HTTP 400 before any session write. The client always sends a valid
- *   compressed secp256k1 key. (flashnet-execution #1169)
  */
 
 /** Maximum number of JSON-RPC requests the gateway accepts in a single batch. */
 export const MAX_JSON_RPC_BATCH_REQUESTS = 100;
 
 /**
- * Stateful filter methods the gateway blocks on all public RPC lanes. They
- * allocate server-side reth filter state and are unsafe on a shared public RPC,
- * so the SDK must not call them; use `eth_getLogs` instead.
+ * Stateful filter methods the gateway does not accept on the public RPC
+ * surface. They allocate server-side filter state and are unsafe on a shared
+ * public RPC, so the SDK must not call them; use `eth_getLogs` instead.
  */
 export const GATEWAY_BLOCKED_STATEFUL_FILTER_METHODS = [
   "eth_newFilter",

--- a/src/execution/gateway-rpc-policy.ts
+++ b/src/execution/gateway-rpc-policy.ts
@@ -1,0 +1,69 @@
+/**
+ * Gateway RPC contract the execution client must honor.
+ *
+ * The Flashnet execution gateway hardened its public RPC and admission surface
+ * (see the linked flashnet-execution PRs). This module captures the resulting
+ * contract as the SDK's single source of truth so the execution client — and
+ * future work on it — stays aligned with what the gateway will actually accept:
+ *
+ * - Stateful filter methods are rejected on every public RPC lane because they
+ *   allocate server-side reth filter state on a shared endpoint. Read logs with
+ *   `eth_getLogs` range queries instead of server-side filters.
+ *   (flashnet-execution #1028; also #1025 for the `/access/{apikey}` lane)
+ * - A single JSON-RPC batch may carry at most `MAX_JSON_RPC_BATCH_REQUESTS`
+ *   requests. The execution client uses Multicall3 to aggregate reads into one
+ *   `eth_call` and a non-batching viem `http()` transport, so it does not emit
+ *   JSON-RPC arrays today; cap any future batching at this limit.
+ *   (flashnet-execution #1170)
+ * - `/access/{apikey}` is read-only: a key's `allowed_methods` are intersected
+ *   with the gateway's read-only whitelist, so write/admin methods are denied
+ *   regardless of the key. (flashnet-execution #1025)
+ * - `POST /v1/execute` rejects intents whose `chainId` does not match the
+ *   execution chain with HTTP 400 before any signature/proof work. The client
+ *   always sends `config.chainId`. (flashnet-execution #1090)
+ * - `/v1/auth/challenge` and `/v1/auth/verify` reject a malformed `public_key`
+ *   with HTTP 400 before any session write. The client always sends a valid
+ *   compressed secp256k1 key. (flashnet-execution #1169)
+ */
+
+/** Maximum number of JSON-RPC requests the gateway accepts in a single batch. */
+export const MAX_JSON_RPC_BATCH_REQUESTS = 100;
+
+/**
+ * Stateful filter methods the gateway blocks on all public RPC lanes. They
+ * allocate server-side reth filter state and are unsafe on a shared public RPC,
+ * so the SDK must not call them; use `eth_getLogs` instead.
+ */
+export const GATEWAY_BLOCKED_STATEFUL_FILTER_METHODS = [
+  "eth_newFilter",
+  "eth_newBlockFilter",
+  "eth_newPendingTransactionFilter",
+  "eth_uninstallFilter",
+  "eth_getFilterChanges",
+  "eth_getFilterLogs",
+] as const;
+
+export type GatewayBlockedFilterMethod =
+  (typeof GATEWAY_BLOCKED_STATEFUL_FILTER_METHODS)[number];
+
+const BLOCKED_FILTER_METHODS = new Set<string>(
+  GATEWAY_BLOCKED_STATEFUL_FILTER_METHODS
+);
+
+/** True if `method` is a stateful filter method the gateway rejects. */
+export function isGatewayBlockedStatefulFilter(method: string): boolean {
+  return BLOCKED_FILTER_METHODS.has(method);
+}
+
+/**
+ * Throws if a JSON-RPC batch would exceed the gateway's per-batch limit.
+ * Call this before sending a batched request so the failure is local and clear
+ * rather than a gateway `-32600` rejection of the whole batch.
+ */
+export function assertJsonRpcBatchWithinLimit(count: number): void {
+  if (count > MAX_JSON_RPC_BATCH_REQUESTS) {
+    throw new Error(
+      `JSON-RPC batch of ${count} requests exceeds the gateway limit of ${MAX_JSON_RPC_BATCH_REQUESTS}`
+    );
+  }
+}

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -24,27 +24,40 @@
  * ```
  */
 
+// Conductor contract ABI — the single source of truth TradingClient encodes
+// against internally. Exported for integrators building raw calldata via
+// encodeFunctionData({ abi: conductorAbi, functionName, args }): all swap
+// variants, LP entrypoints, and fee getters.
+export { conductorAbi } from "./abis/conductor";
+export {
+  errorSelector,
+  fetchAbiErrorsFromBlockscout,
+} from "./blockscout-abi";
 // Core client
 export {
-  ExecutionClient,
-  EXECUTION_NETWORK_CONFIGS,
-  type ExecutionClientConfig,
   type DepositParams,
+  EXECUTION_NETWORK_CONFIGS,
+  type ExecuteParams,
+  ExecutionClient,
+  type ExecutionClientConfig,
+  type ProofOptOut,
+  type VerifyDepositParams,
+  VerifyDepositRejectedError,
+  type WaitForIntentOptions,
   type WithdrawParams,
   type WithdrawTokenParams,
-  type ExecuteParams,
-  type WaitForIntentOptions,
-  type VerifyDepositParams,
-  type ProofOptOut,
-  VerifyDepositRejectedError,
 } from "./client";
 
-// SparkWallet → EVM account adapter
+// EVM read helpers
 export {
-  sparkWalletToEvmAccount,
-  type SparkWalletInput,
-} from "./spark-evm-account";
-
+  fetchAllowance,
+  fetchEip1559Fees,
+  fetchNativeBalance,
+  fetchNonce,
+  fetchTokenBalance,
+  fetchTokenInfo,
+  type TokenInfo,
+} from "./evm";
 // Gateway calldata encoding and queries
 export {
   encodeWithdrawSats,
@@ -52,49 +65,58 @@ export {
   querySparkTokenAddress,
   waitForSparkTokenAddress,
 } from "./gateway";
-
-// EVM read helpers
+// Gateway RPC contract the execution client honors (mirrors the gateway's
+// hardened public RPC + admission surface; see linked flashnet-execution PRs).
 export {
-  fetchTokenInfo,
-  fetchTokenBalance,
-  fetchNativeBalance,
-  fetchAllowance,
-  fetchNonce,
-  fetchEip1559Fees,
-  type TokenInfo,
-} from "./evm";
-
+  assertJsonRpcBatchWithinLimit,
+  GATEWAY_BLOCKED_STATEFUL_FILTER_METHODS,
+  type GatewayBlockedFilterMethod,
+  isGatewayBlockedStatefulFilter,
+  MAX_JSON_RPC_BATCH_REQUESTS,
+} from "./gateway-rpc-policy";
 // Pool queries
 export {
-  getPoolAddress,
   fetchPoolInfo,
-  sortTokens,
+  getPoolAddress,
   type PoolInfo,
+  sortTokens,
 } from "./pool";
-
 // Pool creation encoding
 export {
-  encodeCreateBTCPool,
-  encodeCreatePoolParams,
   type CreateBTCPoolParams,
   type CreatePoolParams,
+  encodeCreateBTCPool,
+  encodeCreatePoolParams,
   type PermitSignature,
 } from "./pool-creation";
-
 // Price math
 export {
+  FEE_TIERS,
+  fullRangeTicks,
   priceToSqrtPriceX96,
   sqrtPriceX96ToPrice,
-  fullRangeTicks,
-  FEE_TIERS,
 } from "./price-math";
-
-// Conductor contract ABI — the single source of truth TradingClient encodes
-// against internally. Exported for integrators building raw calldata via
-// encodeFunctionData({ abi: conductorAbi, functionName, args }): all swap
-// variants, LP entrypoints, and fee getters.
-export { conductorAbi } from "./abis/conductor";
-
+// Revert reason decoding
+export {
+  CONDUCTOR_REVERT_ERRORS,
+  DEFAULT_REVERT_ERRORS,
+  type DecodedRevertReason,
+  type DecodeRevertReasonOptions,
+  decodeRevertReason,
+  SOLIDITY_BUILTIN_REVERT_ERRORS,
+  SPARK_GATEWAY_REVERT_ERRORS,
+} from "./revert-reason";
+// SparkWallet → EVM account adapter
+export {
+  type SparkWalletInput,
+  sparkWalletToEvmAccount,
+} from "./spark-evm-account";
+export {
+  extractTxHashFromStatusMessage,
+  type InnermostRevertFrame,
+  type TraceFrame,
+  traceInnermostRevert,
+} from "./trace-revert";
 // Types
 export type {
   Asset,
@@ -105,6 +127,7 @@ export type {
   DepositAsset,
   DepositRejection,
   ExecuteResponse,
+  ExecutionNetworkInfo,
   ExecutionSigner,
   IndexedDepositProof,
   IntentStatus,
@@ -112,40 +135,18 @@ export type {
   NetworkInfo,
   SignedDepositProof,
   SparkNetworkInfo,
-  ExecutionNetworkInfo,
   VerifyDepositsRequest,
   VerifyDepositsResponse,
   VerifyDepositTransfer,
 } from "./types";
 export {
-  DEFAULT_INTENT_TTL_MS,
-  TERMINAL_INTENT_STATUSES,
-  PLACEHOLDER_DEPOSIT_PROOF,
   canonicalIntentId,
+  DEFAULT_INTENT_TTL_MS,
   depositAssetToWire,
   isTerminalIntentStatus,
   normalizeIntentStatus,
+  PLACEHOLDER_DEPOSIT_PROOF,
   resolveExpiresAt,
+  TERMINAL_INTENT_STATUSES,
   u256Hex,
 } from "./types";
-
-// Revert reason decoding
-export {
-  decodeRevertReason,
-  DEFAULT_REVERT_ERRORS,
-  CONDUCTOR_REVERT_ERRORS,
-  SPARK_GATEWAY_REVERT_ERRORS,
-  SOLIDITY_BUILTIN_REVERT_ERRORS,
-  type DecodedRevertReason,
-  type DecodeRevertReasonOptions,
-} from "./revert-reason";
-export {
-  traceInnermostRevert,
-  extractTxHashFromStatusMessage,
-  type InnermostRevertFrame,
-  type TraceFrame,
-} from "./trace-revert";
-export {
-  fetchAbiErrorsFromBlockscout,
-  errorSelector,
-} from "./blockscout-abi";

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -65,8 +65,7 @@ export {
   querySparkTokenAddress,
   waitForSparkTokenAddress,
 } from "./gateway";
-// Gateway RPC contract the execution client honors (mirrors the gateway's
-// hardened public RPC + admission surface; see linked flashnet-execution PRs).
+// Gateway RPC contract the execution client honors (see ./gateway-rpc-policy).
 export {
   assertJsonRpcBatchWithinLimit,
   GATEWAY_BLOCKED_STATEFUL_FILTER_METHODS,

--- a/src/execution/rpc.ts
+++ b/src/execution/rpc.ts
@@ -1,15 +1,18 @@
 /**
  * Shared viem PublicClient factory with Multicall3 support.
+ *
+ * The gateway's public RPC is read-only and hardened (see ./gateway-rpc-policy):
+ * stateful `eth_*Filter` methods are rejected and JSON-RPC batches are capped.
+ * This transport intentionally relies on Multicall3 to aggregate reads into a
+ * single `eth_call` and does NOT enable viem's `http({ batch })` array batching
+ * or filter-based event watching, so it stays within that contract. Read logs
+ * with `eth_getLogs` range queries rather than server-side filters.
  */
 
-import {
-  createPublicClient,
-  defineChain,
-  http,
-  type PublicClient,
-} from "viem";
+import { createPublicClient, defineChain, http, type PublicClient } from "viem";
 
-const MULTICALL3_ADDRESS = "0xcA11bde05977b3631167028862bE2a173976CA11" as const;
+const MULTICALL3_ADDRESS =
+  "0xcA11bde05977b3631167028862bE2a173976CA11" as const;
 
 const clientCache = new Map<string, PublicClient>();
 

--- a/src/execution/rpc.ts
+++ b/src/execution/rpc.ts
@@ -1,7 +1,7 @@
 /**
  * Shared viem PublicClient factory with Multicall3 support.
  *
- * The gateway's public RPC is read-only and hardened (see ./gateway-rpc-policy):
+ * The gateway's public RPC is read-only and constrained (see ./gateway-rpc-policy):
  * stateful `eth_*Filter` methods are rejected and JSON-RPC batches are capped.
  * This transport intentionally relies on Multicall3 to aggregate reads into a
  * single `eth_call` and does NOT enable viem's `http({ batch })` array batching


### PR DESCRIPTION
## What

Adds a single source of truth in the `execution` module for the JSON-RPC usage policy the execution client follows, so client code and downstream consumers stay within the RPC surface the gateway accepts. This is additive guardrails + docs, with no behavioral change to the client.

The execution client already conforms:

- Reads go through Multicall3 (`eth_call`) and `eth_getLogs` — no `eth_*Filter` calls.
- The viem transport is plain `http()` with no array batching, so the client never emits a JSON-RPC batch.
- It always sends the configured `chainId` and a valid compressed secp256k1 auth public key.

## Changes

- `src/execution/gateway-rpc-policy.ts` (new) — the client RPC policy in one place:
  - `MAX_JSON_RPC_BATCH_REQUESTS = 100`
  - `GATEWAY_BLOCKED_STATEFUL_FILTER_METHODS` — the six stateful `eth_*Filter` methods, plus `isGatewayBlockedStatefulFilter()`
  - `assertJsonRpcBatchWithinLimit()` — fail fast locally instead of round-tripping an oversized batch
- `src/execution/gateway-rpc-policy.spec.ts` (new) — covers the blocked set, the read-only allow-list, and the batch boundary
- `src/execution/rpc.ts` — documents that the transport intentionally stays non-batching and filter-free
- `src/execution/index.ts` — re-exports the new policy surface
- `CHANGELOG.md` — `### Added` note under `[Unreleased]`

## Verification

- `tsc --noEmit` clean
- `jest src/execution/gateway-rpc-policy.spec.ts` — 3/3 pass
- biome-formatted


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Export gateway RPC policy constants and helpers from the execution module
> - Adds [gateway-rpc-policy.ts](https://github.com/flashnetxyz/ts-sdk/pull/83/files#diff-bfad5367706b56f4d9c583195db82399f0c8300846a2282962df62908c2b2fed) with `MAX_JSON_RPC_BATCH_REQUESTS` (100), `GATEWAY_BLOCKED_STATEFUL_FILTER_METHODS` (six `eth_*Filter` methods), `isGatewayBlockedStatefulFilter`, `assertJsonRpcBatchWithinLimit`, and the `GatewayBlockedFilterMethod` union type.
> - Exports all new symbols from the `@flashnet/sdk/execution` barrel so callers can validate batches and filter methods locally before sending requests to the gateway.
> - Adds a comment to [rpc.ts](https://github.com/flashnetxyz/ts-sdk/pull/83/files#diff-c2acb60b393b707188d97c202346f2c76640372c1cabbf9aa552db8ff68f8f8b) documenting the gateway's public RPC constraints (no batch arrays, no filter-based watching, Multicall3-based transport).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5686bef.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
